### PR TITLE
docs(root): document response_format parameter

### DIFF
--- a/.changeset/docs-response-format.md
+++ b/.changeset/docs-response-format.md
@@ -1,0 +1,7 @@
+---
+"@side-quest/bun-runner": patch
+"@side-quest/biome-runner": patch
+"@side-quest/tsc-runner": patch
+---
+
+Document response_format parameter in README files

--- a/packages/biome-runner/README.md
+++ b/packages/biome-runner/README.md
@@ -27,6 +27,10 @@ Or in `.mcp.json`:
 }
 ```
 
+## Response Format
+
+All tools accept a `response_format` parameter (`"markdown"` or `"json"`). Use `"json"` for token-efficient structured output in agent pipelines.
+
 ## License
 
 MIT

--- a/packages/bun-runner/README.md
+++ b/packages/bun-runner/README.md
@@ -27,6 +27,10 @@ Or in `.mcp.json`:
 }
 ```
 
+## Response Format
+
+All tools accept a `response_format` parameter (`"markdown"` or `"json"`). Use `"json"` for token-efficient structured output in agent pipelines.
+
 ## License
 
 MIT

--- a/packages/tsc-runner/README.md
+++ b/packages/tsc-runner/README.md
@@ -25,6 +25,10 @@ Or in `.mcp.json`:
 }
 ```
 
+## Response Format
+
+All tools accept a `response_format` parameter (`"markdown"` or `"json"`). Use `"json"` for token-efficient structured output in agent pipelines.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Add `response_format` section to all 3 package READMEs
- Includes changeset for patch bump (1.0.0 → 1.0.1)

## Test plan

- [ ] PR merges to main
- [ ] Publish workflow creates version PR (changesets action)
- [ ] Merge version PR → publish workflow publishes 1.0.1 via OIDC
- [ ] Per-package GitHub releases created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package documentation across biome-runner, bun-runner, and tsc-runner with new Response Format parameter details
  * Parameter accepts "markdown" or "json" values to structure response output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->