### PR TITLE
fix(ci): remove aggressive @* cleanup that breaks changesets

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -77,7 +77,6 @@ jobs:
           echo "Before cleanup: $ROGUE_COUNT rogue folders found in project root"
 
           find . -maxdepth 1 -type d -name '*@@@*' -exec rm -rf {} + 2>/dev/null || true
-          find . -maxdepth 1 -type d -name '@*' ! -name '.@*' -exec rm -rf {} + 2>/dev/null || true
           find . -maxdepth 1 -type d -regex '.*/[a-z].*@[0-9].*' -exec rm -rf {} + 2>/dev/null || true
           rm -rf node_modules/.bun node_modules/.old_modules* 2>/dev/null || true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,9 +97,9 @@ jobs:
       - name: Clean Bun linker artifacts
         run: |
           # Bun 1.3.x hoisted linker leaks packages to project root
-          # Delete @@@* suffixed folders, scoped packages (@*), and versioned packages
+          # Only clean the @@@-suffixed artifacts (the actual bug), not all @* dirs
+          # which would break the changesets action's module resolution
           find . -maxdepth 1 -type d -name '*@@@*' -exec rm -rf {} + 2>/dev/null || true
-          find . -maxdepth 1 -type d -name '@*' ! -name '.@*' -exec rm -rf {} + 2>/dev/null || true
           find . -maxdepth 1 -type d -regex '.*/[a-z].*@[0-9].*' -exec rm -rf {} + 2>/dev/null || true
           rm -rf node_modules/.bun node_modules/.old_modules* 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

- Remove `find . -maxdepth 1 -type d -name '@*'` from Bun linker cleanup
- This pattern was deleting all scoped package dirs at root, which broke `@changesets/cli` resolution
- Keep `@@@*` cleanup (actual Bun linker bug artifacts) and versioned dir cleanup

## Root Cause

The changesets action failed with "Have you forgotten to install @changesets/cli?" because the aggressive cleanup step deleted scoped package directories that Bun's module resolution depends on.

## Test plan

- [ ] Merge this PR → publish workflow runs on main
- [ ] Changesets action finds `@changesets/cli` and creates version PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined workflow cleanup procedures in automated build and publish processes to be more selective with directory removal, preserving patterns necessary for proper module resolution while maintaining cleanup of specific build artifacts
  * Added documentation clarifying the refined cleanup strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->