### PR TITLE
fix(ci): ensure changesets CLI is Node-resolvable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Ensure changesets CLI is Node-resolvable
+        run: |
+          # The changesets/action uses Node.js require() internally.
+          # Bun's module layout may not be resolvable by Node, so install
+          # @changesets/cli via npm as a fallback to guarantee resolution.
+          if ! node -e "require.resolve('@changesets/cli')" 2>/dev/null; then
+            echo "::notice::@changesets/cli not Node-resolvable, installing via npm"
+            npm install --no-save @changesets/cli @changesets/changelog-github
+          fi
+
       - name: Fix conflicting registry in bunfig.toml
         run: |
           # Setup Bun creates bunfig.toml with registry, which conflicts with Setup Node's registry.


### PR DESCRIPTION
## Summary

- Add fallback step to install @changesets/cli via npm if Node.js can't resolve it
- Bun's symlink-based node_modules layout isn't compatible with the changesets/action's Node.js require()

## Root Cause

The changesets/action runs in Node.js and uses `require()` to find `@changesets/cli`. Bun's module layout uses symlinks through `.bun/` which Node.js can't follow.

## Test plan

- [ ] Merge → publish workflow runs → changesets action resolves @changesets/cli
- [ ] Creates version PR bumping all 3 packages to 1.0.1