### PR TITLE
fix(ci): unconditionally install changesets via npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,12 +88,10 @@ jobs:
       - name: Ensure changesets CLI is Node-resolvable
         run: |
           # The changesets/action uses Node.js require() internally.
-          # Bun's module layout may not be resolvable by Node, so install
-          # @changesets/cli via npm as a fallback to guarantee resolution.
-          if ! node -e "require.resolve('@changesets/cli')" 2>/dev/null; then
-            echo "::notice::@changesets/cli not Node-resolvable, installing via npm"
-            npm install --no-save @changesets/cli @changesets/changelog-github
-          fi
+          # Bun's module layout uses .bun/ symlinks that Node can resolve in shell
+          # but the action's bundled JS runtime cannot. Always install via npm to
+          # guarantee a Node-compatible module layout exists.
+          npm install --no-save @changesets/cli @changesets/changelog-github
 
       - name: Fix conflicting registry in bunfig.toml
         run: |


### PR DESCRIPTION
## Summary

- Remove conditional `require.resolve` check and always install `@changesets/cli` via npm
- Bun's `.bun/` symlink module layout resolves fine from shell but fails within the changesets/action bundled JS runtime
- This is the root cause of the "Have you forgotten to install @changesets/cli" error on every publish run

## Context

Three consecutive publish failures (#2, #3, #4) all hit the same error. The conditional check (`node -e "require.resolve('@changesets/cli')"`) passes in a shell step but the action's internal JS runtime has different resolution behavior that can't follow Bun's symlinks.

## Test plan

- [ ] Merge to main and verify publish workflow passes the changesets action step