### PR TITLE
fix(ci): install changesets into separate prefix with NODE_PATH

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,10 +88,12 @@ jobs:
       - name: Ensure changesets CLI is Node-resolvable
         run: |
           # The changesets/action uses Node.js require() internally.
-          # Bun's module layout uses .bun/ symlinks that Node can resolve in shell
-          # but the action's bundled JS runtime cannot. Always install via npm to
-          # guarantee a Node-compatible module layout exists.
-          npm install --no-save @changesets/cli @changesets/changelog-github
+          # Bun's module layout uses .bun/ symlinks that the action's bundled JS
+          # runtime cannot resolve. npm install --no-save also fails because npm
+          # can't parse Bun's node_modules layout.
+          # Solution: install into a separate prefix and add to NODE_PATH.
+          npm install --prefix .npm-changesets @changesets/cli @changesets/changelog-github
+          echo "NODE_PATH=$(pwd)/.npm-changesets/node_modules" >> "$GITHUB_ENV"
 
       - name: Fix conflicting registry in bunfig.toml
         run: |


### PR DESCRIPTION
## Summary

- Install `@changesets/cli` into a separate `--prefix` directory to avoid npm crashing on Bun's module layout
- Export `NODE_PATH` so the changesets action's bundled JS can resolve the package

## Problem

1. Bun's `.bun/` symlink module layout isn't compatible with the changesets action's internal `require.resolve`
2. `npm install --no-save` crashes with `Cannot read properties of null (reading 'matches')` because npm can't parse Bun's node_modules

## Solution

Install into `.npm-changesets/` prefix (isolated from Bun's layout) and set `NODE_PATH` env var.

## Test plan

- [ ] Publish workflow passes the "Changesets - open PR or publish" step