### PR TITLE
fix(ci): stop removing node_modules/.bun which breaks module resolution

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -78,7 +78,7 @@ jobs:
 
           find . -maxdepth 1 -type d -name '*@@@*' -exec rm -rf {} + 2>/dev/null || true
           find . -maxdepth 1 -type d -regex '.*/[a-z].*@[0-9].*' -exec rm -rf {} + 2>/dev/null || true
-          rm -rf node_modules/.bun node_modules/.old_modules* 2>/dev/null || true
+          rm -rf node_modules/.old_modules* 2>/dev/null || true
 
           REMAINING=$(find . -maxdepth 1 -type d ! -name '.' | grep -Evc "^\./($KNOWN_DIRS)$" || echo 0)
           echo "After cleanup: $REMAINING folders remaining"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,7 +111,7 @@ jobs:
           # which would break the changesets action's module resolution
           find . -maxdepth 1 -type d -name '*@@@*' -exec rm -rf {} + 2>/dev/null || true
           find . -maxdepth 1 -type d -regex '.*/[a-z].*@[0-9].*' -exec rm -rf {} + 2>/dev/null || true
-          rm -rf node_modules/.bun node_modules/.old_modules* 2>/dev/null || true
+          rm -rf node_modules/.old_modules* 2>/dev/null || true
 
       - name: Disable git hooks for CI commits
         run: git config --global core.hooksPath /dev/null


### PR DESCRIPTION
## Summary

- Remove `rm -rf node_modules/.bun` from cleanup steps in both publish.yml and pr-quality.yml
- Bun uses `node_modules/.bun/` for its internal module resolution; deleting it breaks subpath export resolution for packages like `@side-quest/core/logging`

## Problem

CI tests fail with `Cannot find module '@side-quest/core/logging'` and `'@side-quest/core/fs'` because the cleanup step deletes `node_modules/.bun` which Bun needs for package resolution.

## Test plan

- [ ] PR quality tests pass (biome-runner, tsc-runner no longer fail with module resolution errors)