### PR TITLE
fix(root): gitignore .npm-changesets directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage/
 
 # Dependencies
 node_modules/
+.npm-changesets/
 # Bun linker artifacts (hoisted mode creates these in project root)
 # See: https://github.com/oven-sh/bun/issues/23615
 *@@@*/


### PR DESCRIPTION
## Summary

Add `.npm-changesets/` to `.gitignore` to prevent the npm prefix directory (used for changesets Node.js compatibility) from being committed to version PRs.

## Test plan

- [ ] Version PR no longer includes .npm-changesets/ files