### PR TITLE
fix(runners): preserve import.meta.main with target: bun

### DIFF
--- a/packages/biome-runner/CHANGELOG.md
+++ b/packages/biome-runner/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @side-quest/biome-runner
 
+## 1.0.2
+
+### Patch Changes
+
+- Fix import.meta.main being transformed to \_\_require by adding target: 'bun' to bunup config
+
+  The bunup bundler was transforming `import.meta.main` into CommonJS-style `__require.main == __require.module`, but the output format is ESM where `__require` doesn't exist. Adding `target: 'bun'` preserves Bun-specific features and adds the `// @bun` pragma.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/biome-runner/bunup.config.ts
+++ b/packages/biome-runner/bunup.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
 	dts: true,
 	clean: true,
 	splitting: false,
+	target: 'bun',
 })

--- a/packages/biome-runner/package.json
+++ b/packages/biome-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@side-quest/biome-runner",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Biome linter & formatter MCP server — structured diagnostics for Claude Code",
 	"author": {
 		"name": "Nathan Vale",

--- a/packages/bun-runner/CHANGELOG.md
+++ b/packages/bun-runner/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @side-quest/bun-runner
 
+## 1.0.2
+
+### Patch Changes
+
+- Fix import.meta.main being transformed to \_\_require by adding target: 'bun' to bunup config
+
+  The bunup bundler was transforming `import.meta.main` into CommonJS-style `__require.main == __require.module`, but the output format is ESM where `__require` doesn't exist. Adding `target: 'bun'` preserves Bun-specific features and adds the `// @bun` pragma.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/bun-runner/bunup.config.ts
+++ b/packages/bun-runner/bunup.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
 	dts: true,
 	clean: true,
 	splitting: false,
+	target: 'bun',
 })

--- a/packages/bun-runner/package.json
+++ b/packages/bun-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@side-quest/bun-runner",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Bun test runner MCP server — structured, token-efficient test output for Claude Code",
 	"author": {
 		"name": "Nathan Vale",

--- a/packages/tsc-runner/CHANGELOG.md
+++ b/packages/tsc-runner/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @side-quest/tsc-runner
 
+## 1.0.2
+
+### Patch Changes
+
+- Fix import.meta.main being transformed to \_\_require by adding target: 'bun' to bunup config
+
+  The bunup bundler was transforming `import.meta.main` into CommonJS-style `__require.main == __require.module`, but the output format is ESM where `__require` doesn't exist. Adding `target: 'bun'` preserves Bun-specific features and adds the `// @bun` pragma.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/tsc-runner/bunup.config.ts
+++ b/packages/tsc-runner/bunup.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
 	dts: true,
 	clean: true,
 	splitting: false,
+	target: 'bun',
 })

--- a/packages/tsc-runner/package.json
+++ b/packages/tsc-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@side-quest/tsc-runner",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "TypeScript type checker MCP server — structured diagnostics for Claude Code",
 	"author": {
 		"name": "Nathan Vale",


### PR DESCRIPTION
## Summary

Fixes the `__require is not defined` error when running runners via `bunx`.

## Problem

The bunup bundler was transforming `import.meta.main` into CommonJS-style:
```js
if (__require.main == __require.module) {
```

But the output format is ESM where `__require` doesn't exist, causing:
```
ReferenceError: __require is not defined
```

## Solution

Add `target: 'bun'` to `bunup.config.ts` for all three runners. This:
1. Preserves `import.meta.main` as-is (no transformation)
2. Adds `// @bun` pragma which tells Bun's runtime not to re-transpile
3. Adds `#!/usr/bin/env bun` shebang

## Changes

- `packages/bun-runner/bunup.config.ts` - add `target: 'bun'`
- `packages/biome-runner/bunup.config.ts` - add `target: 'bun'`
- `packages/tsc-runner/bunup.config.ts` - add `target: 'bun'`

## Test Plan

- [x] `bun test` - 14 tests pass
- [x] `bun run build` - all three build successfully
- [x] Verified `dist/index.js` contains `import.meta.main` (not `__require`)
- [x] Verified `// @bun` pragma present in output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed import.meta.main transformation in biome-runner, bun-runner, and tsc-runner packages (v1.0.2). This patch resolves an issue where Bun-specific features were being incorrectly transformed during the build process. Updates ensure proper output formatting and maintain compatibility with Bun runtime features, preventing unintended conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->