### PR TITLE
chore(ci): sync dependabot-auto-merge from template

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,17 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Require dev-dependencies label
+      - name: Require auto-mergeable label
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: labels
         with:
           script: |
             const labels = (context.payload.pull_request.labels || []).map(l => l.name)
-            const hasDevLabel = labels.includes('dev-dependencies')
-            if (!hasDevLabel) {
-              core.setFailed('PR is not labeled dev-dependencies; skipping auto-merge')
+            const allowed = ['dev-dependencies', 'github_actions']
+            const hasAllowed = labels.some(l => allowed.includes(l))
+            if (!hasAllowed) {
+              core.setFailed(`PR labels [${labels.join(', ')}] do not include any of: ${allowed.join(', ')}`)
             }
-      - name: Check changed files for devDependencies only
+      - name: Check changed files are safe to auto-merge
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: diff
         with:
@@ -41,11 +42,12 @@ jobs:
               'yarn.lock',
               'bun.lock',
             ]
-            const onlyAllowed = filenames.every(f => allowed.includes(f))
-            if (!onlyAllowed) {
-              core.setFailed('PR touches files outside dependency manifests')
+            const isGHA = filenames.every(f => f.startsWith('.github/'))
+            const isDeps = filenames.every(f => allowed.includes(f))
+            if (!isGHA && !isDeps) {
+              core.setFailed('PR touches files outside dependency manifests and .github/')
             }
-      - name: Enable auto-merge for minor/patch dev dependency updates
+      - name: Enable auto-merge for minor/patch dependency updates
         if: steps.diff.outcome == 'success' && steps.labels.outcome == 'success'
         uses: fastify/github-action-merge-dependabot@1b2ed42db8f9d81a46bac83adedfc03eb5149dff # v3.11.2
         with:


### PR DESCRIPTION
## Summary

- Sync `dependabot-auto-merge.yml` from `nathanvale/bun-typescript-starter` template
- Allow `github_actions` labeled PRs to auto-merge (previously only `dev-dependencies`)
- Allow `.github/` file changes in the safety check (GH Actions bumps only touch workflow files)

## Test plan

- [ ] Verify Dependabot GH Actions PRs now pass the auto-merge gate