### PR TITLE
chore(ci): sync dependabot auto-merge and fix package hygiene

### DIFF
--- a/.github/workflows/package-hygiene.yml
+++ b/.github/workflows/package-hygiene.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     paths:
       - 'package.json'
-      - 'src/**'
+      - 'packages/*/mcp/**'
+      - 'packages/*/bunup.config.ts'
       - 'tsconfig.*'
       - '.github/workflows/package-hygiene.yml'
 concurrency:

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
 		"test:ci": "TF_BUILD=true bun run --filter '*' test",
 		"test:coverage": "bun run --filter '*' test:coverage",
 		"test:watch": "bun test --watch",
+		"check:publint": "for pkg in packages/*/; do echo \"--- $pkg ---\" && bunx publint \"$pkg\"; done",
+		"check:types": "for pkg in packages/*/; do echo \"--- $pkg ---\" && bunx @arethetypeswrong/cli --pack \"$pkg\"; done",
+		"pack:dry": "mkdir -p .pack && for pkg in packages/*/; do (cd \"$pkg\" && bun pm pack --destination ../../.pack); done",
 		"typecheck": "bun run --filter '*' typecheck",
 		"validate": "bun run lint && bun run typecheck && bun run build && TF_BUILD=true bun run test",
 		"version:pre": "changeset version"


### PR DESCRIPTION
## Summary

- Sync `dependabot-auto-merge.yml` from upstream template (fixes auto-merge skipping on Dependabot PRs)
- Add missing `check:publint`, `check:types`, and `pack:dry` scripts to root `package.json` so the `package-hygiene` workflow actually works
- Fix `package-hygiene.yml` path triggers from `src/**` to `packages/*/mcp/**` + `packages/*/bunup.config.ts` to match monorepo layout

## Test plan

- [x] `bun run check:publint` -- all 3 packages pass
- [x] `bun run check:types` -- runs (CJS warning expected for ESM-only packages, `continue-on-error` in workflow)
- [x] `bun run pack:dry` -- all 3 tarballs generated to `.pack/`
- [x] `actionlint` -- 0 errors across all 17 workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to refine build triggers.
  * Added new development scripts for package validation and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->