### PR TITLE
fix(runners): prevent orphaned MCP processes via parent-liveness watcher

### DIFF
--- a/.changeset/fix-orphaned-mcp-processes.md
+++ b/.changeset/fix-orphaned-mcp-processes.md
@@ -1,0 +1,9 @@
+---
+'@side-quest/bun-runner': patch
+'@side-quest/biome-runner': patch
+'@side-quest/tsc-runner': patch
+---
+
+Add parent-liveness watcher so MCP runners exit promptly when their parent Claude Code session (or sub-agent) dies without delivering SIGTERM. Previously, runners were reparented to PID 1 and persisted indefinitely, accumulating dozens of orphaned `bun` processes across a workday.
+
+The watcher polls `process.ppid` every 5 seconds and triggers the existing graceful shutdown path when the parent disappears. The poll interval is configurable via the `MCP_PARENT_CHECK_MS` environment variable (set to `0` to disable; minimum effective value is 50ms).

--- a/docs/plans/2026-04-27-001-fix-orphaned-mcp-processes-plan.md
+++ b/docs/plans/2026-04-27-001-fix-orphaned-mcp-processes-plan.md
@@ -1,0 +1,246 @@
+---
+title: Prevent orphaned MCP runner processes after parent Claude Code session dies
+type: fix
+status: completed
+date: 2026-04-27
+---
+
+# Prevent orphaned MCP runner processes after parent Claude Code session dies
+
+## Overview
+
+Add a parent-liveness watcher to all three MCP runners (`bun-runner`, `biome-runner`, `tsc-runner`) so they exit promptly when their parent Claude Code process (or sub-agent) dies without delivering SIGTERM. Today each runner relies on `transport.onclose` plus SIGINT/SIGTERM handlers, which do not reliably fire when the parent is killed abruptly or when sub-agents tear down. The result is dozens of orphaned `bun` processes accumulating across a working day.
+
+## Problem Frame
+
+Per [issue #56](https://github.com/nathanvale/side-quest-runners/issues/56):
+
+- Each Claude Code session spawns ~4 bun MCP servers; **every sub-agent invocation spawns 4 more**.
+- When the parent dies (or a sub-agent finishes), the runner is reparented to PID 1 and persists indefinitely.
+- After a typical workday: 39 bun processes observed, only 8 belonging to the active session.
+- Sub-agents are the dominant leak source — a session with 5–10 sub-agent calls leaks 20–40 processes.
+
+The existing `transport.onclose` handler should detect stdio pipe closure but evidently does not fire in all parent-death scenarios on macOS. The runners need a defensive watcher that does not depend on the SDK transport noticing the disconnect.
+
+## Requirements Trace
+
+- R1. When the parent process of a runner dies, the runner exits within ~5 seconds (cleanly disposing the server and logger sinks).
+- R2. The detection mechanism works on macOS (Apple Silicon, Bun v1.x) — the user's primary environment.
+- R3. The watcher does not interfere with normal request/response operation under an active parent (no spurious exits, no measurable performance impact on hot paths).
+- R4. All three first-party MCP runners receive the same fix with the same observable behavior.
+- R5. The fix is verifiable without booting Claude Code — there is a deterministic test that proves a runner exits after its parent dies.
+
+## Scope Boundaries
+
+- Not changing the `x-api` MCP server (lives outside this repo). Fix in this repo applies only to `bun-runner`, `biome-runner`, `tsc-runner`.
+- Not introducing a shared utility package. Per `.claude/CLAUDE.md`, each runner is intentionally self-contained; the parent-liveness watcher is duplicated across the three packages (small, ~30 lines).
+- Not adding a Claude Code `Stop` lifecycle hook. The user-installed harness is out of scope; the runners must defend themselves.
+- Not changing the existing SIGINT/SIGTERM handlers or `transport.onclose` shutdown path — those remain as the primary path. The watcher is a backstop.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/bun-runner/mcp/index.ts:1143-1180` — `startBunServer` shutdown wiring (canonical pattern; biome and tsc are near-identical).
+- `packages/biome-runner/mcp/index.ts:1222-1260` — same pattern.
+- `packages/tsc-runner/mcp/index.ts:1110-1148` — same pattern.
+- `packages/bun-runner/mcp/index.test.ts` — bun:test structure (unit + integration via `InMemoryTransport`).
+- `scripts/smoke/run-smoke.ts` — subprocess smoke-test harness that spawns the built binary via `StdioClientTransport`. The new lifecycle test fits naturally as a smoke-style subprocess test.
+
+### Institutional Learnings
+
+- `docs/solutions/` is mostly empty (only `integration-issues/`); no prior art for this class of fix.
+
+### External References
+
+- Node.js `process.ppid` is available on Bun and reflects the current parent. After reparenting to init, `ppid === 1` on Unix.
+- POSIX `prctl(PR_SET_PDEATHSIG)` is Linux-only — unavailable on macOS, so it cannot be the primary mechanism.
+- The MCP TypeScript SDK's `StdioServerTransport.onclose` fires when stdin emits `end`. In practice this is unreliable when the parent is SIGKILL'd: the kernel closes the pipe but Bun's stdin readable stream does not always surface the `end` event before another I/O wakeup. PPID polling is the standard fallback.
+
+---
+
+## Key Technical Decisions
+
+- **PPID polling, not stdin watching.** `setInterval(() => { if (process.ppid === 1) shutdown() }, 5000)` is the simplest, most reliable mechanism on macOS. It catches every parent-death scenario regardless of how the parent died and regardless of whether stdin EOF was delivered.
+- **5-second poll interval.** Balances responsiveness (orphans gone within ~5s) against overhead (one syscall per 5s is negligible). Configurable via `MCP_PARENT_CHECK_MS` env var for tests. Parsing rules: `<= 0` disables the watcher entirely; unparseable / empty / `NaN` falls back to the 5000ms default; positive values are clamped to a minimum of 50ms to prevent event-loop saturation.
+- **`unref()` the timer.** The interval handle must not keep the event loop alive on its own — otherwise it would prevent clean shutdown via the existing paths.
+- **Initial PPID capture.** Capture `process.ppid` at startup; if it ever changes (including to 1), trigger shutdown. This catches reparenting even if init's PID weren't 1 in some exotic environment, and is more semantically honest than hard-coding `=== 1`.
+- **Reuse the existing `shutdown()` function.** No new shutdown path. The watcher just calls the same function as SIGTERM/onclose, so logger disposal and `server.close()` already happen.
+- **Duplicate across the three runners.** Each runner is self-contained per repo policy. The watcher is ~30 lines; a shared package is not justified.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the watcher be a shared utility?** No. Repo policy keeps each runner self-contained.
+- **Linux-specific signal mechanism?** No. macOS is the primary environment and `prctl` is not available.
+- **Touch x-api?** No. Out of repo.
+
+### Deferred to Implementation
+
+- None. The existing `shuttingDown` flag in `shutdown()` already guarantees re-entry safety, so a timer tick concurrent with a signal handler is a non-issue. No new deferred unknowns.
+
+---
+
+## Implementation Units
+
+- U1. **Add parent-liveness watcher to bun-runner**
+
+**Goal:** Make `bun-runner` exit within ~5s when its parent dies.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/bun-runner/mcp/index.ts`
+- Modify: `packages/bun-runner/mcp/index.test.ts`
+
+**Approach:**
+- Inside `startBunServer`, after the existing transport/signal wiring, capture `const initialPpid = process.ppid`.
+- Read poll interval from `process.env.MCP_PARENT_CHECK_MS` per the parsing rules in Key Technical Decisions (default 5000; `<= 0` disables; unparseable falls back to default; positive values clamped to a 50ms minimum).
+- `setInterval` that compares `process.ppid` to `initialPpid` (or to `1`) and calls the existing `shutdown()` when divergent.
+- Call `.unref()` on the interval handle so it never keeps the event loop alive on its own.
+- Log a single `lifecycleLogger.info` line on detection, including the observed PPID, before invoking `shutdown()`.
+
+**Patterns to follow:**
+- Existing `shutdown()` in `startBunServer` (`packages/bun-runner/mcp/index.ts:1149-1164`) — idempotent guard already in place.
+- `lifecycleLogger` usage already established in the same function.
+
+**Test scenarios:**
+- Happy path: `startBunServer` returns normally and the interval is registered (spy `setInterval` and assert the returned handle had `.unref()` called).
+- Edge case: `MCP_PARENT_CHECK_MS=0` (and any negative value) skips watcher registration entirely.
+- Edge case: `MCP_PARENT_CHECK_MS` set to a non-numeric / empty / `NaN` string falls back to the 5000 default.
+- Edge case: `MCP_PARENT_CHECK_MS=1` is clamped up to the 50ms minimum (assert the value passed to `setInterval`).
+- Edge case: invoking the interval callback when `process.ppid` is unchanged does not trigger shutdown.
+- Integration: invoking the interval callback after stubbing `process.ppid` to `1` calls `shutdown()` exactly once even when invoked twice in quick succession (idempotency).
+
+**Verification:**
+- Unit tests pass via `bun_testFile` for `packages/bun-runner/mcp/index.test.ts`.
+- `tsc_check` passes for the package.
+
+---
+
+- U2. **Add parent-liveness watcher to biome-runner**
+
+**Goal:** Mirror U1 in `biome-runner` with identical behavior.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** U1 (establishes the canonical shape)
+
+**Files:**
+- Modify: `packages/biome-runner/mcp/index.ts`
+- Modify: `packages/biome-runner/mcp/index.test.ts`
+
+**Approach:**
+- Apply the U1 change verbatim inside `startBiomeServer` (`packages/biome-runner/mcp/index.ts:1222-1260`).
+- Keep the literal code shape identical to bun-runner so future readers can diff the three implementations and see they match.
+
+**Patterns to follow:**
+- The version landed in U1.
+
+**Test scenarios:**
+- Same four scenarios as U1, adapted to `startBiomeServer`.
+
+**Verification:**
+- Unit tests pass for `packages/biome-runner/mcp/index.test.ts`.
+- `tsc_check` passes.
+
+---
+
+- U3. **Add parent-liveness watcher to tsc-runner**
+
+**Goal:** Mirror U1 in `tsc-runner`.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/tsc-runner/mcp/index.ts`
+- Modify: `packages/tsc-runner/mcp/index.test.ts`
+
+**Approach:**
+- Apply the U1 change verbatim inside `startTscServer` (`packages/tsc-runner/mcp/index.ts:1110-1148`).
+
+**Patterns to follow:**
+- The version landed in U1.
+
+**Test scenarios:**
+- Same four scenarios as U1, adapted to `startTscServer`.
+
+**Verification:**
+- Unit tests pass for `packages/tsc-runner/mcp/index.test.ts`.
+- `tsc_check` passes.
+
+---
+
+- U4. **End-to-end orphan-detection smoke test**
+
+**Goal:** Prove the fix works against a *built* binary in a real subprocess — not just the unit-level interval callback.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** U1, U2, U3 (all binaries need the watcher built)
+
+**Files:**
+- Create: `scripts/smoke/orphan-detection.test.ts` (or extend `scripts/smoke/run-smoke.ts` with a new case — choose during implementation)
+- Modify: `package.json` if a new script entry is needed.
+
+**Approach:**
+- For each of the three built MCP server binaries (`packages/*/dist/index.js`):
+  1. Spawn an intermediate `bun -e` process. The intermediate `Bun.spawn`s the runner binary with **`stdio: ['ignore', 'ignore', 'ignore']`** (or equivalently a held-open FIFO that the test process owns) so the runner's stdin is *not* coupled to the intermediate. This is load-bearing: it ensures killing the intermediate does not close the runner's stdin, which would fire `transport.onclose` via the existing path and mask whether the watcher actually triggered the exit.
+  2. The intermediate writes the runner's PID to its stdout (which the test reads), then idles.
+  3. Set `MCP_PARENT_CHECK_MS=200` on the runner so the test runs in ~1s.
+  4. Test SIGKILLs the intermediate's PID directly (not the process group). Runner reparents to PID 1.
+  5. Poll `kill(runnerPid, 0)` until it throws ESRCH, with a 5s timeout.
+  6. Assert the runner exited.
+- Run the new test as part of `bun test:smoke` so `bun run validate` covers it.
+
+**Patterns to follow:**
+- `scripts/smoke/run-smoke.ts` for spawning built binaries and waiting on lifecycle events.
+
+**Test scenarios:**
+- Happy path: each of the three runners exits within 5s of intermediate-parent death (with `MCP_PARENT_CHECK_MS=200` and stdin detached).
+- Negative control: with `MCP_PARENT_CHECK_MS=0` (watcher disabled) and stdin detached, the runner **stays alive** for at least 2s after the intermediate dies. This is the proof that the watcher — not `transport.onclose` — is the active mechanism in the happy-path test. If this scenario ever shows the runner exiting, the stdin detachment is leaking and the happy-path test is no longer trustworthy.
+- Edge case: with `MCP_PARENT_CHECK_MS=10000` (much longer than the test window) and stdin detached, the runner stays alive for the duration of the test window — confirming the timer is the only path firing and the interval value is honored.
+
+**Verification:**
+- `bun test:smoke` passes locally.
+- `bun run validate` passes.
+- Manual sanity check: run a built runner under a shell, kill the shell, confirm the runner exits within ~5s.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Only the runner startup path is touched. No request handler, no tool, no transport internals.
+- **Error propagation:** The watcher routes through the existing `shutdown()` function, so logger flush and `server.close()` already happen and any errors during disposal are already handled.
+- **State lifecycle risks:** None — the watcher is idempotent via the existing `shuttingDown` guard.
+- **API surface parity:** All three runners get the same change, preserving the convention that they evolve together.
+- **Integration coverage:** The U4 smoke test is the integration backstop; unit tests cover the watcher logic in isolation.
+- **Unchanged invariants:** The existing `transport.onclose` and SIGINT/SIGTERM shutdown paths are preserved unchanged. The watcher is additive.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `process.ppid` semantics differ across Bun versions or platforms. | Capture `initialPpid` at startup and compare against it; also treat `=== 1` as a death signal. Smoke test runs against the actual built binary on the user's platform. |
+| 5s poll is too slow for users who notice orphans during rapid sub-agent churn. | `MCP_PARENT_CHECK_MS` env var lets users tune down to ~200ms if needed. Default is conservative. |
+| Watcher fires during a brief reparenting window that legitimately ends with PPID 1 (e.g., daemonization). | Runners are not daemonized — they're stdio children of Claude Code. PPID 1 unambiguously means the parent is gone. |
+| Smoke test is flaky on slow CI. | Use `MCP_PARENT_CHECK_MS=200` and a 5s wall-clock timeout — 25× headroom. |
+
+---
+
+## Sources & References
+
+- Issue: [#56](https://github.com/nathanvale/side-quest-runners/issues/56)
+- Related code: `packages/bun-runner/mcp/index.ts:1143`, `packages/biome-runner/mcp/index.ts:1222`, `packages/tsc-runner/mcp/index.ts:1110`
+- Smoke harness: `scripts/smoke/run-smoke.ts`

--- a/packages/biome-runner/mcp/index.test.ts
+++ b/packages/biome-runner/mcp/index.test.ts
@@ -496,7 +496,7 @@ describe('createParentLivenessWatcher', () => {
 		}
 	})
 
-	test('invokes onParentDeath when ppid changes from initial', async () => {
+	test('invokes onParentDeath once when ppid changes from initial', async () => {
 		let currentPpid = 1234
 		let calls = 0
 		const handle = createParentLivenessWatcher({
@@ -511,14 +511,33 @@ describe('createParentLivenessWatcher', () => {
 			await new Promise((resolve) => setTimeout(resolve, 80))
 			expect(calls).toBe(0)
 			currentPpid = 1
-			await new Promise((resolve) => setTimeout(resolve, 120))
-			expect(calls).toBeGreaterThanOrEqual(1)
+			await new Promise((resolve) => setTimeout(resolve, 180))
+			expect(calls).toBe(1)
 		} finally {
 			clearInterval(handle as ReturnType<typeof setInterval>)
 		}
 	})
 
-	test('invokes onParentDeath when ppid is 1 even if equal to initial (defensive)', async () => {
+	test('invokes onParentDeath once when initial parent process is gone', async () => {
+		let calls = 0
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1234,
+			getPpid: () => 1234,
+			isParentAlive: () => false,
+			onParentDeath: () => {
+				calls += 1
+			},
+			intervalMs: 50,
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 180))
+			expect(calls).toBe(1)
+		} finally {
+			clearInterval(handle as ReturnType<typeof setInterval>)
+		}
+	})
+
+	test('does not invoke onParentDeath when ppid starts and remains 1', async () => {
 		let calls = 0
 		const handle = createParentLivenessWatcher({
 			initialPpid: 1,
@@ -530,7 +549,7 @@ describe('createParentLivenessWatcher', () => {
 		})
 		try {
 			await new Promise((resolve) => setTimeout(resolve, 120))
-			expect(calls).toBeGreaterThanOrEqual(1)
+			expect(calls).toBe(0)
 		} finally {
 			clearInterval(handle as ReturnType<typeof setInterval>)
 		}

--- a/packages/biome-runner/mcp/index.test.ts
+++ b/packages/biome-runner/mcp/index.test.ts
@@ -462,6 +462,10 @@ describe('createParentLivenessWatcher', () => {
 	})
 
 	test('registers a timer with .unref applied so it does not block the loop', () => {
+		// If unref were missing, this test process would hang for the interval
+		// duration after all other work completed. Use a long interval so the
+		// callback never fires during the test, and rely on bun:test exiting
+		// promptly as evidence that unref is in effect.
 		const handle = createParentLivenessWatcher({
 			initialPpid: 1234,
 			getPpid: () => 1234,

--- a/packages/biome-runner/mcp/index.test.ts
+++ b/packages/biome-runner/mcp/index.test.ts
@@ -10,7 +10,11 @@ import {
 	compactLintSummaryForJsonText,
 	createBiomeInvocation,
 	createBiomeServer,
+	createParentLivenessWatcher,
+	DEFAULT_PARENT_CHECK_MS,
+	MIN_PARENT_CHECK_MS,
 	parseBiomeOutput,
+	parseParentCheckMs,
 	SERVER_VERSION,
 	spawnWithTimeout,
 	validatePath,
@@ -394,6 +398,137 @@ describe('biome tools integration', () => {
 		} finally {
 			await Promise.all([client.close(), server.close()])
 			await rm(fixtureDir, { recursive: true, force: true })
+		}
+	})
+})
+
+describe('parseParentCheckMs', () => {
+	test('returns default when env is undefined', () => {
+		expect(parseParentCheckMs(undefined)).toBe(DEFAULT_PARENT_CHECK_MS)
+	})
+
+	test('returns default for empty / whitespace string', () => {
+		expect(parseParentCheckMs('')).toBe(DEFAULT_PARENT_CHECK_MS)
+		expect(parseParentCheckMs('   ')).toBe(DEFAULT_PARENT_CHECK_MS)
+	})
+
+	test('returns default for non-numeric / NaN values', () => {
+		expect(parseParentCheckMs('abc')).toBe(DEFAULT_PARENT_CHECK_MS)
+		expect(parseParentCheckMs('NaN')).toBe(DEFAULT_PARENT_CHECK_MS)
+	})
+
+	test('returns 0 (disabled) for zero', () => {
+		expect(parseParentCheckMs('0')).toBe(0)
+	})
+
+	test('returns 0 (disabled) for negative values', () => {
+		expect(parseParentCheckMs('-1')).toBe(0)
+		expect(parseParentCheckMs('-9999')).toBe(0)
+	})
+
+	test('clamps tiny positive values up to MIN_PARENT_CHECK_MS', () => {
+		expect(parseParentCheckMs('1')).toBe(MIN_PARENT_CHECK_MS)
+		expect(parseParentCheckMs('49')).toBe(MIN_PARENT_CHECK_MS)
+	})
+
+	test('passes through values at or above the minimum', () => {
+		expect(parseParentCheckMs('50')).toBe(50)
+		expect(parseParentCheckMs('200')).toBe(200)
+		expect(parseParentCheckMs('5000')).toBe(5000)
+	})
+})
+
+describe('createParentLivenessWatcher', () => {
+	test('returns undefined when intervalMs <= 0 (disabled)', () => {
+		const onParentDeath = () => {
+			throw new Error('should not be called')
+		}
+		expect(
+			createParentLivenessWatcher({
+				initialPpid: 1234,
+				getPpid: () => 1234,
+				onParentDeath,
+				intervalMs: 0,
+			}),
+		).toBeUndefined()
+		expect(
+			createParentLivenessWatcher({
+				initialPpid: 1234,
+				getPpid: () => 1234,
+				onParentDeath,
+				intervalMs: -1,
+			}),
+		).toBeUndefined()
+	})
+
+	test('registers a timer with .unref applied so it does not block the loop', () => {
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1234,
+			getPpid: () => 1234,
+			onParentDeath: () => {
+				throw new Error('should not be called when ppid unchanged')
+			},
+			intervalMs: 60_000,
+		})
+		expect(handle).toBeDefined()
+		clearInterval(handle as ReturnType<typeof setInterval>)
+	})
+
+	test('does not invoke onParentDeath while ppid is unchanged', async () => {
+		let calls = 0
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1234,
+			getPpid: () => 1234,
+			onParentDeath: () => {
+				calls += 1
+			},
+			intervalMs: 50,
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 180))
+			expect(calls).toBe(0)
+		} finally {
+			clearInterval(handle as ReturnType<typeof setInterval>)
+		}
+	})
+
+	test('invokes onParentDeath when ppid changes from initial', async () => {
+		let currentPpid = 1234
+		let calls = 0
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1234,
+			getPpid: () => currentPpid,
+			onParentDeath: () => {
+				calls += 1
+			},
+			intervalMs: 50,
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 80))
+			expect(calls).toBe(0)
+			currentPpid = 1
+			await new Promise((resolve) => setTimeout(resolve, 120))
+			expect(calls).toBeGreaterThanOrEqual(1)
+		} finally {
+			clearInterval(handle as ReturnType<typeof setInterval>)
+		}
+	})
+
+	test('invokes onParentDeath when ppid is 1 even if equal to initial (defensive)', async () => {
+		let calls = 0
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1,
+			getPpid: () => 1,
+			onParentDeath: () => {
+				calls += 1
+			},
+			intervalMs: 50,
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 120))
+			expect(calls).toBeGreaterThanOrEqual(1)
+		} finally {
+			clearInterval(handle as ReturnType<typeof setInterval>)
 		}
 	})
 })

--- a/packages/biome-runner/mcp/index.test.ts
+++ b/packages/biome-runner/mcp/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, spyOn, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import path from 'node:path'
@@ -461,21 +461,30 @@ describe('createParentLivenessWatcher', () => {
 		).toBeUndefined()
 	})
 
-	test('registers a timer with .unref applied so it does not block the loop', () => {
-		// If unref were missing, this test process would hang for the interval
-		// duration after all other work completed. Use a long interval so the
-		// callback never fires during the test, and rely on bun:test exiting
-		// promptly as evidence that unref is in effect.
-		const handle = createParentLivenessWatcher({
-			initialPpid: 1234,
-			getPpid: () => 1234,
-			onParentDeath: () => {
-				throw new Error('should not be called when ppid unchanged')
-			},
-			intervalMs: 60_000,
-		})
-		expect(handle).toBeDefined()
-		clearInterval(handle as ReturnType<typeof setInterval>)
+	test('calls .unref() on the timer handle so it does not block the loop', () => {
+		// Spy on the Timer prototype's unref so we observe the real call made
+		// by createParentLivenessWatcher. A timing-based assertion would still
+		// pass if unref() were silently removed, because clearInterval also
+		// lets bun:test exit promptly.
+		const probe = setInterval(() => {}, 60_000)
+		const timerProto = Object.getPrototypeOf(probe) as { unref: () => void }
+		clearInterval(probe)
+		const unrefSpy = spyOn(timerProto, 'unref')
+		try {
+			const handle = createParentLivenessWatcher({
+				initialPpid: 1234,
+				getPpid: () => 1234,
+				onParentDeath: () => {
+					throw new Error('should not be called when ppid unchanged')
+				},
+				intervalMs: 60_000,
+			})
+			expect(handle).toBeDefined()
+			expect(unrefSpy).toHaveBeenCalledTimes(1)
+			clearInterval(handle as ReturnType<typeof setInterval>)
+		} finally {
+			unrefSpy.mockRestore()
+		}
 	})
 
 	test('does not invoke onParentDeath while ppid is unchanged', async () => {

--- a/packages/biome-runner/mcp/index.ts
+++ b/packages/biome-runner/mcp/index.ts
@@ -1321,8 +1321,15 @@ export async function startBiomeServer(): Promise<void> {
 				error: error instanceof Error ? error.message : String(error),
 			})
 		}
-		await server.close()
-		process.exit(0)
+		try {
+			await server.close()
+		} catch (error) {
+			lifecycleLogger.error('Failed to close biome-runner server cleanly', {
+				error: error instanceof Error ? error.message : String(error),
+			})
+		} finally {
+			process.exit(0)
+		}
 	}
 
 	transport.onclose = () => {

--- a/packages/biome-runner/mcp/index.ts
+++ b/packages/biome-runner/mcp/index.ts
@@ -1217,6 +1217,69 @@ export async function createBiomeServer(
 }
 
 /**
+ * Default parent-liveness poll interval in milliseconds.
+ */
+export const DEFAULT_PARENT_CHECK_MS = 5000
+
+/**
+ * Lower bound for the poll interval to prevent event-loop saturation.
+ */
+export const MIN_PARENT_CHECK_MS = 50
+
+/**
+ * Parse the MCP_PARENT_CHECK_MS env value into a poll interval.
+ *
+ * Returns 0 to disable the watcher entirely. Otherwise returns the clamped
+ * positive interval. Unparseable / empty / NaN values fall back to the default.
+ */
+export function parseParentCheckMs(raw: string | undefined): number {
+	if (raw === undefined) {
+		return DEFAULT_PARENT_CHECK_MS
+	}
+	const trimmed = raw.trim()
+	if (trimmed === '') {
+		return DEFAULT_PARENT_CHECK_MS
+	}
+	const parsed = Number(trimmed)
+	if (!Number.isFinite(parsed)) {
+		return DEFAULT_PARENT_CHECK_MS
+	}
+	if (parsed <= 0) {
+		return 0
+	}
+	return Math.max(parsed, MIN_PARENT_CHECK_MS)
+}
+
+/**
+ * Watch for parent-process death and invoke onParentDeath when detected.
+ *
+ * On macOS the SDK's stdin EOF is unreliable when the parent is SIGKILLed,
+ * leaving the runner reparented to PID 1 and orphaned. Polling process.ppid
+ * is the simplest reliable backstop.
+ *
+ * The returned interval handle is unref()'d so it never keeps the event loop
+ * alive on its own. Returns undefined when the watcher is disabled.
+ */
+export function createParentLivenessWatcher(opts: {
+	initialPpid: number
+	getPpid: () => number
+	onParentDeath: () => void
+	intervalMs: number
+}): ReturnType<typeof setInterval> | undefined {
+	if (opts.intervalMs <= 0) {
+		return undefined
+	}
+	const handle = setInterval(() => {
+		const current = opts.getPpid()
+		if (current !== opts.initialPpid || current === 1) {
+			opts.onParentDeath()
+		}
+	}, opts.intervalMs)
+	handle.unref()
+	return handle
+}
+
+/**
  * Start the stdio MCP server process.
  */
 export async function startBiomeServer(): Promise<void> {
@@ -1255,6 +1318,21 @@ export async function startBiomeServer(): Promise<void> {
 	})
 	process.on('SIGTERM', () => {
 		void shutdown()
+	})
+
+	const initialPpid = process.ppid
+	const intervalMs = parseParentCheckMs(process.env.MCP_PARENT_CHECK_MS)
+	createParentLivenessWatcher({
+		initialPpid,
+		getPpid: () => process.ppid,
+		intervalMs,
+		onParentDeath: () => {
+			lifecycleLogger.info('Parent process gone, shutting down', {
+				initialPpid,
+				currentPpid: process.ppid,
+			})
+			void shutdown()
+		},
 	})
 }
 

--- a/packages/biome-runner/mcp/index.ts
+++ b/packages/biome-runner/mcp/index.ts
@@ -1263,6 +1263,7 @@ export function parseParentCheckMs(raw: string | undefined): number {
 export function createParentLivenessWatcher(opts: {
 	initialPpid: number
 	getPpid: () => number
+	isParentAlive?: (pid: number) => boolean
 	onParentDeath: () => void
 	intervalMs: number
 }): ReturnType<typeof setInterval> | undefined {
@@ -1271,12 +1272,31 @@ export function createParentLivenessWatcher(opts: {
 	}
 	const handle = setInterval(() => {
 		const current = opts.getPpid()
-		if (current !== opts.initialPpid || current === 1) {
+		if (
+			current !== opts.initialPpid ||
+			opts.isParentAlive?.(opts.initialPpid) === false
+		) {
+			clearInterval(handle)
 			opts.onParentDeath()
 		}
 	}, opts.intervalMs)
 	handle.unref()
 	return handle
+}
+
+/**
+ * Check whether a process exists without sending it a real signal.
+ *
+ * Why: Bun's process.ppid can retain its startup value after reparenting, so
+ * the watcher also probes the original parent PID directly.
+ */
+export function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0)
+		return true
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === 'EPERM'
+	}
 }
 
 /**
@@ -1325,6 +1345,7 @@ export async function startBiomeServer(): Promise<void> {
 	createParentLivenessWatcher({
 		initialPpid,
 		getPpid: () => process.ppid,
+		isParentAlive: isPidAlive,
 		intervalMs,
 		onParentDeath: () => {
 			lifecycleLogger.info('Parent process gone, shutting down', {

--- a/packages/biome-runner/mcp/index.ts
+++ b/packages/biome-runner/mcp/index.ts
@@ -1303,6 +1303,9 @@ export function isPidAlive(pid: number): boolean {
  * Start the stdio MCP server process.
  */
 export async function startBiomeServer(): Promise<void> {
+	// Capture before any await: if the parent dies during async init,
+	// process.ppid reparents to 1 and the original PID is lost.
+	const initialPpid = process.ppid
 	const server = await createBiomeServer()
 	const transport = new StdioServerTransport()
 	let shuttingDown = false
@@ -1347,7 +1350,6 @@ export async function startBiomeServer(): Promise<void> {
 		void shutdown()
 	})
 
-	const initialPpid = process.ppid
 	const intervalMs = parseParentCheckMs(process.env.MCP_PARENT_CHECK_MS)
 	createParentLivenessWatcher({
 		initialPpid,

--- a/packages/bun-runner/mcp/index.test.ts
+++ b/packages/bun-runner/mcp/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, spyOn, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
@@ -608,21 +608,30 @@ describe('createParentLivenessWatcher', () => {
 		).toBeUndefined()
 	})
 
-	test('registers a timer with .unref applied so it does not block the loop', () => {
-		// If unref were missing, this test process would hang for the interval
-		// duration after all other work completed. Use a long interval so the
-		// callback never fires during the test, and rely on bun:test exiting
-		// promptly as evidence that unref is in effect.
-		const handle = createParentLivenessWatcher({
-			initialPpid: 1234,
-			getPpid: () => 1234,
-			onParentDeath: () => {
-				throw new Error('should not be called when ppid unchanged')
-			},
-			intervalMs: 60_000,
-		})
-		expect(handle).toBeDefined()
-		clearInterval(handle as ReturnType<typeof setInterval>)
+	test('calls .unref() on the timer handle so it does not block the loop', () => {
+		// Spy on the Timer prototype's unref so we observe the real call made
+		// by createParentLivenessWatcher. A timing-based assertion would still
+		// pass if unref() were silently removed, because clearInterval also
+		// lets bun:test exit promptly.
+		const probe = setInterval(() => {}, 60_000)
+		const timerProto = Object.getPrototypeOf(probe) as { unref: () => void }
+		clearInterval(probe)
+		const unrefSpy = spyOn(timerProto, 'unref')
+		try {
+			const handle = createParentLivenessWatcher({
+				initialPpid: 1234,
+				getPpid: () => 1234,
+				onParentDeath: () => {
+					throw new Error('should not be called when ppid unchanged')
+				},
+				intervalMs: 60_000,
+			})
+			expect(handle).toBeDefined()
+			expect(unrefSpy).toHaveBeenCalledTimes(1)
+			clearInterval(handle as ReturnType<typeof setInterval>)
+		} finally {
+			unrefSpy.mockRestore()
+		}
 	})
 
 	test('does not invoke onParentDeath while ppid is unchanged', async () => {

--- a/packages/bun-runner/mcp/index.test.ts
+++ b/packages/bun-runner/mcp/index.test.ts
@@ -8,7 +8,11 @@ import {
 	createBunCoverageInvocation,
 	createBunInvocation,
 	createBunServer,
+	createParentLivenessWatcher,
+	DEFAULT_PARENT_CHECK_MS,
 	extractTopStackFrame,
+	MIN_PARENT_CHECK_MS,
+	parseParentCheckMs,
 	SERVER_VERSION,
 	spawnWithTimeout,
 	validatePath,
@@ -541,6 +545,141 @@ describe('bun tools integration', () => {
 			).toBeDefined()
 		} finally {
 			await Promise.all([client.close(), server.close()])
+		}
+	})
+})
+
+describe('parseParentCheckMs', () => {
+	test('returns default when env is undefined', () => {
+		expect(parseParentCheckMs(undefined)).toBe(DEFAULT_PARENT_CHECK_MS)
+	})
+
+	test('returns default for empty / whitespace string', () => {
+		expect(parseParentCheckMs('')).toBe(DEFAULT_PARENT_CHECK_MS)
+		expect(parseParentCheckMs('   ')).toBe(DEFAULT_PARENT_CHECK_MS)
+	})
+
+	test('returns default for non-numeric / NaN values', () => {
+		expect(parseParentCheckMs('abc')).toBe(DEFAULT_PARENT_CHECK_MS)
+		expect(parseParentCheckMs('NaN')).toBe(DEFAULT_PARENT_CHECK_MS)
+	})
+
+	test('returns 0 (disabled) for zero', () => {
+		expect(parseParentCheckMs('0')).toBe(0)
+	})
+
+	test('returns 0 (disabled) for negative values', () => {
+		expect(parseParentCheckMs('-1')).toBe(0)
+		expect(parseParentCheckMs('-9999')).toBe(0)
+	})
+
+	test('clamps tiny positive values up to MIN_PARENT_CHECK_MS', () => {
+		expect(parseParentCheckMs('1')).toBe(MIN_PARENT_CHECK_MS)
+		expect(parseParentCheckMs('49')).toBe(MIN_PARENT_CHECK_MS)
+	})
+
+	test('passes through values at or above the minimum', () => {
+		expect(parseParentCheckMs('50')).toBe(50)
+		expect(parseParentCheckMs('200')).toBe(200)
+		expect(parseParentCheckMs('5000')).toBe(5000)
+	})
+})
+
+describe('createParentLivenessWatcher', () => {
+	test('returns undefined when intervalMs <= 0 (disabled)', () => {
+		const onParentDeath = () => {
+			throw new Error('should not be called')
+		}
+		expect(
+			createParentLivenessWatcher({
+				initialPpid: 1234,
+				getPpid: () => 1234,
+				onParentDeath,
+				intervalMs: 0,
+			}),
+		).toBeUndefined()
+		expect(
+			createParentLivenessWatcher({
+				initialPpid: 1234,
+				getPpid: () => 1234,
+				onParentDeath,
+				intervalMs: -1,
+			}),
+		).toBeUndefined()
+	})
+
+	test('registers a timer with .unref applied so it does not block the loop', () => {
+		// If unref were missing, this test process would hang for the interval
+		// duration after all other work completed. Use a long interval so the
+		// callback never fires during the test, and rely on bun:test exiting
+		// promptly as evidence that unref is in effect.
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1234,
+			getPpid: () => 1234,
+			onParentDeath: () => {
+				throw new Error('should not be called when ppid unchanged')
+			},
+			intervalMs: 60_000,
+		})
+		expect(handle).toBeDefined()
+		clearInterval(handle as ReturnType<typeof setInterval>)
+	})
+
+	test('does not invoke onParentDeath while ppid is unchanged', async () => {
+		let calls = 0
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1234,
+			getPpid: () => 1234,
+			onParentDeath: () => {
+				calls += 1
+			},
+			intervalMs: 50,
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 180))
+			expect(calls).toBe(0)
+		} finally {
+			clearInterval(handle as ReturnType<typeof setInterval>)
+		}
+	})
+
+	test('invokes onParentDeath when ppid changes from initial', async () => {
+		let currentPpid = 1234
+		let calls = 0
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1234,
+			getPpid: () => currentPpid,
+			onParentDeath: () => {
+				calls += 1
+			},
+			intervalMs: 50,
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 80))
+			expect(calls).toBe(0)
+			currentPpid = 1
+			await new Promise((resolve) => setTimeout(resolve, 120))
+			expect(calls).toBeGreaterThanOrEqual(1)
+		} finally {
+			clearInterval(handle as ReturnType<typeof setInterval>)
+		}
+	})
+
+	test('invokes onParentDeath when ppid is 1 even if equal to initial (defensive)', async () => {
+		let calls = 0
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1,
+			getPpid: () => 1,
+			onParentDeath: () => {
+				calls += 1
+			},
+			intervalMs: 50,
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 120))
+			expect(calls).toBeGreaterThanOrEqual(1)
+		} finally {
+			clearInterval(handle as ReturnType<typeof setInterval>)
 		}
 	})
 })

--- a/packages/bun-runner/mcp/index.test.ts
+++ b/packages/bun-runner/mcp/index.test.ts
@@ -643,7 +643,7 @@ describe('createParentLivenessWatcher', () => {
 		}
 	})
 
-	test('invokes onParentDeath when ppid changes from initial', async () => {
+	test('invokes onParentDeath once when ppid changes from initial', async () => {
 		let currentPpid = 1234
 		let calls = 0
 		const handle = createParentLivenessWatcher({
@@ -658,14 +658,33 @@ describe('createParentLivenessWatcher', () => {
 			await new Promise((resolve) => setTimeout(resolve, 80))
 			expect(calls).toBe(0)
 			currentPpid = 1
-			await new Promise((resolve) => setTimeout(resolve, 120))
-			expect(calls).toBeGreaterThanOrEqual(1)
+			await new Promise((resolve) => setTimeout(resolve, 180))
+			expect(calls).toBe(1)
 		} finally {
 			clearInterval(handle as ReturnType<typeof setInterval>)
 		}
 	})
 
-	test('invokes onParentDeath when ppid is 1 even if equal to initial (defensive)', async () => {
+	test('invokes onParentDeath once when initial parent process is gone', async () => {
+		let calls = 0
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1234,
+			getPpid: () => 1234,
+			isParentAlive: () => false,
+			onParentDeath: () => {
+				calls += 1
+			},
+			intervalMs: 50,
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 180))
+			expect(calls).toBe(1)
+		} finally {
+			clearInterval(handle as ReturnType<typeof setInterval>)
+		}
+	})
+
+	test('does not invoke onParentDeath when ppid starts and remains 1', async () => {
 		let calls = 0
 		const handle = createParentLivenessWatcher({
 			initialPpid: 1,
@@ -677,7 +696,7 @@ describe('createParentLivenessWatcher', () => {
 		})
 		try {
 			await new Promise((resolve) => setTimeout(resolve, 120))
-			expect(calls).toBeGreaterThanOrEqual(1)
+			expect(calls).toBe(0)
 		} finally {
 			clearInterval(handle as ReturnType<typeof setInterval>)
 		}

--- a/packages/bun-runner/mcp/index.ts
+++ b/packages/bun-runner/mcp/index.ts
@@ -1224,6 +1224,9 @@ export function isPidAlive(pid: number): boolean {
  * Start the stdio MCP server process.
  */
 export async function startBunServer(): Promise<void> {
+	// Capture before any await: if the parent dies during async init,
+	// process.ppid reparents to 1 and the original PID is lost.
+	const initialPpid = process.ppid
 	const server = await createBunServer()
 	const transport = new StdioServerTransport()
 	let shuttingDown = false
@@ -1268,7 +1271,6 @@ export async function startBunServer(): Promise<void> {
 		void shutdown()
 	})
 
-	const initialPpid = process.ppid
 	const intervalMs = parseParentCheckMs(process.env.MCP_PARENT_CHECK_MS)
 	createParentLivenessWatcher({
 		initialPpid,

--- a/packages/bun-runner/mcp/index.ts
+++ b/packages/bun-runner/mcp/index.ts
@@ -1242,8 +1242,15 @@ export async function startBunServer(): Promise<void> {
 				error: error instanceof Error ? error.message : String(error),
 			})
 		}
-		await server.close()
-		process.exit(0)
+		try {
+			await server.close()
+		} catch (error) {
+			lifecycleLogger.error('Failed to close bun-runner server cleanly', {
+				error: error instanceof Error ? error.message : String(error),
+			})
+		} finally {
+			process.exit(0)
+		}
 	}
 
 	transport.onclose = () => {

--- a/packages/bun-runner/mcp/index.ts
+++ b/packages/bun-runner/mcp/index.ts
@@ -1138,6 +1138,69 @@ export async function createBunServer(
 }
 
 /**
+ * Default parent-liveness poll interval in milliseconds.
+ */
+export const DEFAULT_PARENT_CHECK_MS = 5000
+
+/**
+ * Lower bound for the poll interval to prevent event-loop saturation.
+ */
+export const MIN_PARENT_CHECK_MS = 50
+
+/**
+ * Parse the MCP_PARENT_CHECK_MS env value into a poll interval.
+ *
+ * Returns 0 to disable the watcher entirely. Otherwise returns the clamped
+ * positive interval. Unparseable / empty / NaN values fall back to the default.
+ */
+export function parseParentCheckMs(raw: string | undefined): number {
+	if (raw === undefined) {
+		return DEFAULT_PARENT_CHECK_MS
+	}
+	const trimmed = raw.trim()
+	if (trimmed === '') {
+		return DEFAULT_PARENT_CHECK_MS
+	}
+	const parsed = Number(trimmed)
+	if (!Number.isFinite(parsed)) {
+		return DEFAULT_PARENT_CHECK_MS
+	}
+	if (parsed <= 0) {
+		return 0
+	}
+	return Math.max(parsed, MIN_PARENT_CHECK_MS)
+}
+
+/**
+ * Watch for parent-process death and invoke onParentDeath when detected.
+ *
+ * On macOS the SDK's stdin EOF is unreliable when the parent is SIGKILLed,
+ * leaving the runner reparented to PID 1 and orphaned. Polling process.ppid
+ * is the simplest reliable backstop.
+ *
+ * The returned interval handle is unref()'d so it never keeps the event loop
+ * alive on its own. Returns undefined when the watcher is disabled.
+ */
+export function createParentLivenessWatcher(opts: {
+	initialPpid: number
+	getPpid: () => number
+	onParentDeath: () => void
+	intervalMs: number
+}): ReturnType<typeof setInterval> | undefined {
+	if (opts.intervalMs <= 0) {
+		return undefined
+	}
+	const handle = setInterval(() => {
+		const current = opts.getPpid()
+		if (current !== opts.initialPpid || current === 1) {
+			opts.onParentDeath()
+		}
+	}, opts.intervalMs)
+	handle.unref()
+	return handle
+}
+
+/**
  * Start the stdio MCP server process.
  */
 export async function startBunServer(): Promise<void> {
@@ -1176,6 +1239,21 @@ export async function startBunServer(): Promise<void> {
 	})
 	process.on('SIGTERM', () => {
 		void shutdown()
+	})
+
+	const initialPpid = process.ppid
+	const intervalMs = parseParentCheckMs(process.env.MCP_PARENT_CHECK_MS)
+	createParentLivenessWatcher({
+		initialPpid,
+		getPpid: () => process.ppid,
+		intervalMs,
+		onParentDeath: () => {
+			lifecycleLogger.info('Parent process gone, shutting down', {
+				initialPpid,
+				currentPpid: process.ppid,
+			})
+			void shutdown()
+		},
 	})
 }
 

--- a/packages/bun-runner/mcp/index.ts
+++ b/packages/bun-runner/mcp/index.ts
@@ -1184,6 +1184,7 @@ export function parseParentCheckMs(raw: string | undefined): number {
 export function createParentLivenessWatcher(opts: {
 	initialPpid: number
 	getPpid: () => number
+	isParentAlive?: (pid: number) => boolean
 	onParentDeath: () => void
 	intervalMs: number
 }): ReturnType<typeof setInterval> | undefined {
@@ -1192,12 +1193,31 @@ export function createParentLivenessWatcher(opts: {
 	}
 	const handle = setInterval(() => {
 		const current = opts.getPpid()
-		if (current !== opts.initialPpid || current === 1) {
+		if (
+			current !== opts.initialPpid ||
+			opts.isParentAlive?.(opts.initialPpid) === false
+		) {
+			clearInterval(handle)
 			opts.onParentDeath()
 		}
 	}, opts.intervalMs)
 	handle.unref()
 	return handle
+}
+
+/**
+ * Check whether a process exists without sending it a real signal.
+ *
+ * Why: Bun's process.ppid can retain its startup value after reparenting, so
+ * the watcher also probes the original parent PID directly.
+ */
+export function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0)
+		return true
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === 'EPERM'
+	}
 }
 
 /**
@@ -1246,6 +1266,7 @@ export async function startBunServer(): Promise<void> {
 	createParentLivenessWatcher({
 		initialPpid,
 		getPpid: () => process.ppid,
+		isParentAlive: isPidAlive,
 		intervalMs,
 		onParentDeath: () => {
 			lifecycleLogger.info('Parent process gone, shutting down', {

--- a/packages/tsc-runner/mcp/index.test.ts
+++ b/packages/tsc-runner/mcp/index.test.ts
@@ -9,10 +9,14 @@ import {
 	_resetGitRootCache,
 	buildTscOutput,
 	compactTscOutputForJsonText,
+	createParentLivenessWatcher,
 	createTscInvocation,
 	createTscServer,
+	DEFAULT_PARENT_CHECK_MS,
 	detectTsBuildInfoCorruption,
 	formatTscMarkdown,
+	MIN_PARENT_CHECK_MS,
+	parseParentCheckMs,
 	parseTscOutput,
 	SERVER_VERSION,
 	spawnWithTimeout,
@@ -573,6 +577,137 @@ describe('tsc_check integration', () => {
 			expect(notifications.some((entry) => entry.level === 'error')).toBe(true)
 		} finally {
 			await Promise.all([client.close(), server.close()])
+		}
+	})
+})
+
+describe('parseParentCheckMs', () => {
+	test('returns default when env is undefined', () => {
+		expect(parseParentCheckMs(undefined)).toBe(DEFAULT_PARENT_CHECK_MS)
+	})
+
+	test('returns default for empty / whitespace string', () => {
+		expect(parseParentCheckMs('')).toBe(DEFAULT_PARENT_CHECK_MS)
+		expect(parseParentCheckMs('   ')).toBe(DEFAULT_PARENT_CHECK_MS)
+	})
+
+	test('returns default for non-numeric / NaN values', () => {
+		expect(parseParentCheckMs('abc')).toBe(DEFAULT_PARENT_CHECK_MS)
+		expect(parseParentCheckMs('NaN')).toBe(DEFAULT_PARENT_CHECK_MS)
+	})
+
+	test('returns 0 (disabled) for zero', () => {
+		expect(parseParentCheckMs('0')).toBe(0)
+	})
+
+	test('returns 0 (disabled) for negative values', () => {
+		expect(parseParentCheckMs('-1')).toBe(0)
+		expect(parseParentCheckMs('-9999')).toBe(0)
+	})
+
+	test('clamps tiny positive values up to MIN_PARENT_CHECK_MS', () => {
+		expect(parseParentCheckMs('1')).toBe(MIN_PARENT_CHECK_MS)
+		expect(parseParentCheckMs('49')).toBe(MIN_PARENT_CHECK_MS)
+	})
+
+	test('passes through values at or above the minimum', () => {
+		expect(parseParentCheckMs('50')).toBe(50)
+		expect(parseParentCheckMs('200')).toBe(200)
+		expect(parseParentCheckMs('5000')).toBe(5000)
+	})
+})
+
+describe('createParentLivenessWatcher', () => {
+	test('returns undefined when intervalMs <= 0 (disabled)', () => {
+		const onParentDeath = () => {
+			throw new Error('should not be called')
+		}
+		expect(
+			createParentLivenessWatcher({
+				initialPpid: 1234,
+				getPpid: () => 1234,
+				onParentDeath,
+				intervalMs: 0,
+			}),
+		).toBeUndefined()
+		expect(
+			createParentLivenessWatcher({
+				initialPpid: 1234,
+				getPpid: () => 1234,
+				onParentDeath,
+				intervalMs: -1,
+			}),
+		).toBeUndefined()
+	})
+
+	test('registers a timer with .unref applied so it does not block the loop', () => {
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1234,
+			getPpid: () => 1234,
+			onParentDeath: () => {
+				throw new Error('should not be called when ppid unchanged')
+			},
+			intervalMs: 60_000,
+		})
+		expect(handle).toBeDefined()
+		clearInterval(handle as ReturnType<typeof setInterval>)
+	})
+
+	test('does not invoke onParentDeath while ppid is unchanged', async () => {
+		let calls = 0
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1234,
+			getPpid: () => 1234,
+			onParentDeath: () => {
+				calls += 1
+			},
+			intervalMs: 50,
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 180))
+			expect(calls).toBe(0)
+		} finally {
+			clearInterval(handle as ReturnType<typeof setInterval>)
+		}
+	})
+
+	test('invokes onParentDeath when ppid changes from initial', async () => {
+		let currentPpid = 1234
+		let calls = 0
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1234,
+			getPpid: () => currentPpid,
+			onParentDeath: () => {
+				calls += 1
+			},
+			intervalMs: 50,
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 80))
+			expect(calls).toBe(0)
+			currentPpid = 1
+			await new Promise((resolve) => setTimeout(resolve, 120))
+			expect(calls).toBeGreaterThanOrEqual(1)
+		} finally {
+			clearInterval(handle as ReturnType<typeof setInterval>)
+		}
+	})
+
+	test('invokes onParentDeath when ppid is 1 even if equal to initial (defensive)', async () => {
+		let calls = 0
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1,
+			getPpid: () => 1,
+			onParentDeath: () => {
+				calls += 1
+			},
+			intervalMs: 50,
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 120))
+			expect(calls).toBeGreaterThanOrEqual(1)
+		} finally {
+			clearInterval(handle as ReturnType<typeof setInterval>)
 		}
 	})
 })

--- a/packages/tsc-runner/mcp/index.test.ts
+++ b/packages/tsc-runner/mcp/index.test.ts
@@ -641,6 +641,10 @@ describe('createParentLivenessWatcher', () => {
 	})
 
 	test('registers a timer with .unref applied so it does not block the loop', () => {
+		// If unref were missing, this test process would hang for the interval
+		// duration after all other work completed. Use a long interval so the
+		// callback never fires during the test, and rely on bun:test exiting
+		// promptly as evidence that unref is in effect.
 		const handle = createParentLivenessWatcher({
 			initialPpid: 1234,
 			getPpid: () => 1234,

--- a/packages/tsc-runner/mcp/index.test.ts
+++ b/packages/tsc-runner/mcp/index.test.ts
@@ -640,21 +640,30 @@ describe('createParentLivenessWatcher', () => {
 		).toBeUndefined()
 	})
 
-	test('registers a timer with .unref applied so it does not block the loop', () => {
-		// If unref were missing, this test process would hang for the interval
-		// duration after all other work completed. Use a long interval so the
-		// callback never fires during the test, and rely on bun:test exiting
-		// promptly as evidence that unref is in effect.
-		const handle = createParentLivenessWatcher({
-			initialPpid: 1234,
-			getPpid: () => 1234,
-			onParentDeath: () => {
-				throw new Error('should not be called when ppid unchanged')
-			},
-			intervalMs: 60_000,
-		})
-		expect(handle).toBeDefined()
-		clearInterval(handle as ReturnType<typeof setInterval>)
+	test('calls .unref() on the timer handle so it does not block the loop', () => {
+		// Spy on the Timer prototype's unref so we observe the real call made
+		// by createParentLivenessWatcher. A timing-based assertion would still
+		// pass if unref() were silently removed, because clearInterval also
+		// lets bun:test exit promptly.
+		const probe = setInterval(() => {}, 60_000)
+		const timerProto = Object.getPrototypeOf(probe) as { unref: () => void }
+		clearInterval(probe)
+		const unrefSpy = spyOn(timerProto, 'unref')
+		try {
+			const handle = createParentLivenessWatcher({
+				initialPpid: 1234,
+				getPpid: () => 1234,
+				onParentDeath: () => {
+					throw new Error('should not be called when ppid unchanged')
+				},
+				intervalMs: 60_000,
+			})
+			expect(handle).toBeDefined()
+			expect(unrefSpy).toHaveBeenCalledTimes(1)
+			clearInterval(handle as ReturnType<typeof setInterval>)
+		} finally {
+			unrefSpy.mockRestore()
+		}
 	})
 
 	test('does not invoke onParentDeath while ppid is unchanged', async () => {

--- a/packages/tsc-runner/mcp/index.test.ts
+++ b/packages/tsc-runner/mcp/index.test.ts
@@ -675,7 +675,7 @@ describe('createParentLivenessWatcher', () => {
 		}
 	})
 
-	test('invokes onParentDeath when ppid changes from initial', async () => {
+	test('invokes onParentDeath once when ppid changes from initial', async () => {
 		let currentPpid = 1234
 		let calls = 0
 		const handle = createParentLivenessWatcher({
@@ -690,14 +690,33 @@ describe('createParentLivenessWatcher', () => {
 			await new Promise((resolve) => setTimeout(resolve, 80))
 			expect(calls).toBe(0)
 			currentPpid = 1
-			await new Promise((resolve) => setTimeout(resolve, 120))
-			expect(calls).toBeGreaterThanOrEqual(1)
+			await new Promise((resolve) => setTimeout(resolve, 180))
+			expect(calls).toBe(1)
 		} finally {
 			clearInterval(handle as ReturnType<typeof setInterval>)
 		}
 	})
 
-	test('invokes onParentDeath when ppid is 1 even if equal to initial (defensive)', async () => {
+	test('invokes onParentDeath once when initial parent process is gone', async () => {
+		let calls = 0
+		const handle = createParentLivenessWatcher({
+			initialPpid: 1234,
+			getPpid: () => 1234,
+			isParentAlive: () => false,
+			onParentDeath: () => {
+				calls += 1
+			},
+			intervalMs: 50,
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 180))
+			expect(calls).toBe(1)
+		} finally {
+			clearInterval(handle as ReturnType<typeof setInterval>)
+		}
+	})
+
+	test('does not invoke onParentDeath when ppid starts and remains 1', async () => {
 		let calls = 0
 		const handle = createParentLivenessWatcher({
 			initialPpid: 1,
@@ -709,7 +728,7 @@ describe('createParentLivenessWatcher', () => {
 		})
 		try {
 			await new Promise((resolve) => setTimeout(resolve, 120))
-			expect(calls).toBeGreaterThanOrEqual(1)
+			expect(calls).toBe(0)
 		} finally {
 			clearInterval(handle as ReturnType<typeof setInterval>)
 		}

--- a/packages/tsc-runner/mcp/index.ts
+++ b/packages/tsc-runner/mcp/index.ts
@@ -1149,6 +1149,7 @@ export function parseParentCheckMs(raw: string | undefined): number {
 export function createParentLivenessWatcher(opts: {
 	initialPpid: number
 	getPpid: () => number
+	isParentAlive?: (pid: number) => boolean
 	onParentDeath: () => void
 	intervalMs: number
 }): ReturnType<typeof setInterval> | undefined {
@@ -1157,12 +1158,31 @@ export function createParentLivenessWatcher(opts: {
 	}
 	const handle = setInterval(() => {
 		const current = opts.getPpid()
-		if (current !== opts.initialPpid || current === 1) {
+		if (
+			current !== opts.initialPpid ||
+			opts.isParentAlive?.(opts.initialPpid) === false
+		) {
+			clearInterval(handle)
 			opts.onParentDeath()
 		}
 	}, opts.intervalMs)
 	handle.unref()
 	return handle
+}
+
+/**
+ * Check whether a process exists without sending it a real signal.
+ *
+ * Why: Bun's process.ppid can retain its startup value after reparenting, so
+ * the watcher also probes the original parent PID directly.
+ */
+export function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0)
+		return true
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === 'EPERM'
+	}
 }
 
 /**
@@ -1213,6 +1233,7 @@ export async function startTscServer(): Promise<void> {
 	createParentLivenessWatcher({
 		initialPpid,
 		getPpid: () => process.ppid,
+		isParentAlive: isPidAlive,
 		intervalMs,
 		onParentDeath: () => {
 			lifecycleLogger.info('Parent process gone, shutting down', {

--- a/packages/tsc-runner/mcp/index.ts
+++ b/packages/tsc-runner/mcp/index.ts
@@ -1103,6 +1103,69 @@ export async function createTscServer(
 }
 
 /**
+ * Default parent-liveness poll interval in milliseconds.
+ */
+export const DEFAULT_PARENT_CHECK_MS = 5000
+
+/**
+ * Lower bound for the poll interval to prevent event-loop saturation.
+ */
+export const MIN_PARENT_CHECK_MS = 50
+
+/**
+ * Parse the MCP_PARENT_CHECK_MS env value into a poll interval.
+ *
+ * Returns 0 to disable the watcher entirely. Otherwise returns the clamped
+ * positive interval. Unparseable / empty / NaN values fall back to the default.
+ */
+export function parseParentCheckMs(raw: string | undefined): number {
+	if (raw === undefined) {
+		return DEFAULT_PARENT_CHECK_MS
+	}
+	const trimmed = raw.trim()
+	if (trimmed === '') {
+		return DEFAULT_PARENT_CHECK_MS
+	}
+	const parsed = Number(trimmed)
+	if (!Number.isFinite(parsed)) {
+		return DEFAULT_PARENT_CHECK_MS
+	}
+	if (parsed <= 0) {
+		return 0
+	}
+	return Math.max(parsed, MIN_PARENT_CHECK_MS)
+}
+
+/**
+ * Watch for parent-process death and invoke onParentDeath when detected.
+ *
+ * On macOS the SDK's stdin EOF is unreliable when the parent is SIGKILLed,
+ * leaving the runner reparented to PID 1 and orphaned. Polling process.ppid
+ * is the simplest reliable backstop.
+ *
+ * The returned interval handle is unref()'d so it never keeps the event loop
+ * alive on its own. Returns undefined when the watcher is disabled.
+ */
+export function createParentLivenessWatcher(opts: {
+	initialPpid: number
+	getPpid: () => number
+	onParentDeath: () => void
+	intervalMs: number
+}): ReturnType<typeof setInterval> | undefined {
+	if (opts.intervalMs <= 0) {
+		return undefined
+	}
+	const handle = setInterval(() => {
+		const current = opts.getPpid()
+		if (current !== opts.initialPpid || current === 1) {
+			opts.onParentDeath()
+		}
+	}, opts.intervalMs)
+	handle.unref()
+	return handle
+}
+
+/**
  * Start the stdio MCP server process.
  *
  * Why: explicit lifecycle wiring keeps shutdown reliable in CLI-hosted runs.
@@ -1143,6 +1206,21 @@ export async function startTscServer(): Promise<void> {
 	})
 	process.on('SIGTERM', () => {
 		void shutdown()
+	})
+
+	const initialPpid = process.ppid
+	const intervalMs = parseParentCheckMs(process.env.MCP_PARENT_CHECK_MS)
+	createParentLivenessWatcher({
+		initialPpid,
+		getPpid: () => process.ppid,
+		intervalMs,
+		onParentDeath: () => {
+			lifecycleLogger.info('Parent process gone, shutting down', {
+				initialPpid,
+				currentPpid: process.ppid,
+			})
+			void shutdown()
+		},
 	})
 }
 

--- a/packages/tsc-runner/mcp/index.ts
+++ b/packages/tsc-runner/mcp/index.ts
@@ -1191,6 +1191,9 @@ export function isPidAlive(pid: number): boolean {
  * Why: explicit lifecycle wiring keeps shutdown reliable in CLI-hosted runs.
  */
 export async function startTscServer(): Promise<void> {
+	// Capture before any await: if the parent dies during async init,
+	// process.ppid reparents to 1 and the original PID is lost.
+	const initialPpid = process.ppid
 	const server = await createTscServer()
 	const transport = new StdioServerTransport()
 	let shuttingDown = false
@@ -1235,7 +1238,6 @@ export async function startTscServer(): Promise<void> {
 		void shutdown()
 	})
 
-	const initialPpid = process.ppid
 	const intervalMs = parseParentCheckMs(process.env.MCP_PARENT_CHECK_MS)
 	createParentLivenessWatcher({
 		initialPpid,

--- a/packages/tsc-runner/mcp/index.ts
+++ b/packages/tsc-runner/mcp/index.ts
@@ -1209,8 +1209,15 @@ export async function startTscServer(): Promise<void> {
 				error: error instanceof Error ? error.message : String(error),
 			})
 		}
-		await server.close()
-		process.exit(0)
+		try {
+			await server.close()
+		} catch (error) {
+			lifecycleLogger.error('Failed to close tsc-runner server cleanly', {
+				error: error instanceof Error ? error.message : String(error),
+			})
+		} finally {
+			process.exit(0)
+		}
 	}
 
 	transport.onclose = () => {

--- a/scripts/smoke/run-smoke.ts
+++ b/scripts/smoke/run-smoke.ts
@@ -528,6 +528,14 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 			})
 			try {
 				intermediate.kill('SIGKILL')
+				// Verify the intermediate is actually dead before measuring the
+				// runner's lifetime — otherwise a silently-failed SIGKILL would
+				// pass the alive-after-2s assertion for the wrong reason.
+				await intermediate.exited
+				assert(
+					!isProcessAlive(intermediate.pid as number),
+					`${runner.name}: intermediate process ${intermediate.pid} did not exit after SIGKILL`,
+				)
 				await new Promise((resolve) => setTimeout(resolve, 2000))
 				assert(
 					isProcessAlive(runnerPid),

--- a/scripts/smoke/run-smoke.ts
+++ b/scripts/smoke/run-smoke.ts
@@ -44,6 +44,7 @@ interface ProductionRunnerBinary {
 
 const REPO_ROOT = path.resolve(import.meta.dir, '..', '..')
 const TOOL_TIMEOUT_MS = 15_000
+const ORPHAN_RUNNER_STARTUP_SETTLE_MS = 500
 const PRODUCTION_RUNNER_BINARIES: ProductionRunnerBinary[] = [
 	{
 		name: 'tsc-runner',
@@ -394,14 +395,16 @@ async function spawnDetachedRunner(args: {
 	parentCheckMs: string
 }): Promise<{ intermediate: ReturnType<typeof Bun.spawn>; runnerPid: number }> {
 	const intermediateScript = `
-		const proc = Bun.spawn({
-			cmd: ['bun', process.env.RUNNER_ENTRY],
+		const { spawn } = require('node:child_process');
+		const proc = spawn('bun', [process.env.RUNNER_ENTRY], {
+			detached: true,
 			stdio: ['ignore', 'ignore', 'ignore'],
 			env: {
 				...process.env,
 				MCP_PARENT_CHECK_MS: process.env.MCP_PARENT_CHECK_MS,
 			},
 		});
+		proc.unref();
 		process.stdout.write(String(proc.pid) + '\\n');
 		// Idle forever; the parent harness kills this process.
 		setInterval(() => {}, 60_000);
@@ -480,6 +483,24 @@ function isProcessAlive(pid: number): boolean {
 	}
 }
 
+function killRunnerProcessGroup(pid: number): void {
+	try {
+		process.kill(-pid, 'SIGKILL')
+		return
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code
+		if (code === 'ESRCH') {
+			return
+		}
+	}
+
+	try {
+		process.kill(pid, 'SIGKILL')
+	} catch {
+		// Ignore: runner may have already exited.
+	}
+}
+
 async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
 	const deadline = Date.now() + timeoutMs
 	while (Date.now() < deadline) {
@@ -489,6 +510,12 @@ async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
 		await new Promise((resolve) => setTimeout(resolve, 50))
 	}
 	return false
+}
+
+async function waitForRunnerStartupSettle(): Promise<void> {
+	await new Promise((resolve) =>
+		setTimeout(resolve, ORPHAN_RUNNER_STARTUP_SETTLE_MS),
+	)
 }
 
 async function buildProductionRunnerBinaries(): Promise<void> {
@@ -524,6 +551,7 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 					isProcessAlive(runnerPid),
 					`${runner.name}: runner not alive after spawn`,
 				)
+				await waitForRunnerStartupSettle()
 				intermediate.kill('SIGKILL')
 				const exited = await waitForExit(runnerPid, 5000)
 				assert(
@@ -532,11 +560,7 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 				)
 			} finally {
 				if (isProcessAlive(runnerPid)) {
-					try {
-						process.kill(runnerPid, 'SIGKILL')
-					} catch {
-						// Ignore.
-					}
+					killRunnerProcessGroup(runnerPid)
 				}
 				try {
 					intermediate.kill('SIGKILL')
@@ -555,6 +579,7 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 				parentCheckMs: '0',
 			})
 			try {
+				await waitForRunnerStartupSettle()
 				intermediate.kill('SIGKILL')
 				// Verify the intermediate is actually dead before measuring the
 				// runner's lifetime — otherwise a silently-failed SIGKILL would
@@ -571,11 +596,7 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 				)
 			} finally {
 				if (isProcessAlive(runnerPid)) {
-					try {
-						process.kill(runnerPid, 'SIGKILL')
-					} catch {
-						// Ignore.
-					}
+					killRunnerProcessGroup(runnerPid)
 				}
 				try {
 					intermediate.kill('SIGKILL')
@@ -594,6 +615,7 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 				parentCheckMs: '10000',
 			})
 			try {
+				await waitForRunnerStartupSettle()
 				intermediate.kill('SIGKILL')
 				await new Promise((resolve) => setTimeout(resolve, 1000))
 				assert(
@@ -602,11 +624,7 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 				)
 			} finally {
 				if (isProcessAlive(runnerPid)) {
-					try {
-						process.kill(runnerPid, 'SIGKILL')
-					} catch {
-						// Ignore.
-					}
+					killRunnerProcessGroup(runnerPid)
 				}
 				try {
 					intermediate.kill('SIGKILL')

--- a/scripts/smoke/run-smoke.ts
+++ b/scripts/smoke/run-smoke.ts
@@ -36,8 +36,31 @@ interface ToolResult {
 	structuredContent?: Record<string, unknown>
 }
 
+interface ProductionRunnerBinary {
+	name: 'tsc-runner' | 'bun-runner' | 'biome-runner'
+	packageDir: string
+	entrypoint: string
+}
+
 const REPO_ROOT = path.resolve(import.meta.dir, '..', '..')
 const TOOL_TIMEOUT_MS = 15_000
+const PRODUCTION_RUNNER_BINARIES: ProductionRunnerBinary[] = [
+	{
+		name: 'tsc-runner',
+		packageDir: path.join(REPO_ROOT, 'packages/tsc-runner'),
+		entrypoint: path.join(REPO_ROOT, 'packages/tsc-runner/dist/index.js'),
+	},
+	{
+		name: 'bun-runner',
+		packageDir: path.join(REPO_ROOT, 'packages/bun-runner'),
+		entrypoint: path.join(REPO_ROOT, 'packages/bun-runner/dist/index.js'),
+	},
+	{
+		name: 'biome-runner',
+		packageDir: path.join(REPO_ROOT, 'packages/biome-runner'),
+		entrypoint: path.join(REPO_ROOT, 'packages/biome-runner/dist/index.js'),
+	},
+]
 
 function assert(condition: unknown, message: string): asserts condition {
 	if (!condition) {
@@ -468,27 +491,32 @@ async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
 	return false
 }
 
-async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
-	const runners = [
-		{
-			name: 'tsc-runner',
-			path: path.join(REPO_ROOT, 'packages/tsc-runner/dist/index.js'),
-		},
-		{
-			name: 'bun-runner',
-			path: path.join(REPO_ROOT, 'packages/bun-runner/dist/index.js'),
-		},
-		{
-			name: 'biome-runner',
-			path: path.join(REPO_ROOT, 'packages/biome-runner/dist/index.js'),
-		},
-	]
+async function buildProductionRunnerBinaries(): Promise<void> {
+	console.log('[smoke] building production runner binaries...')
 
-	for (const runner of runners) {
+	for (const runner of PRODUCTION_RUNNER_BINARIES) {
+		const proc = Bun.spawn(['bun', 'run', 'build'], {
+			cwd: runner.packageDir,
+			stdout: 'inherit',
+			stderr: 'inherit',
+			env: process.env,
+		})
+		const exitCode = await proc.exited
+		assert(
+			exitCode === 0,
+			`${runner.name}: build failed with exit code ${exitCode}`,
+		)
+	}
+}
+
+async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
+	await buildProductionRunnerBinaries()
+
+	for (const runner of PRODUCTION_RUNNER_BINARIES) {
 		// Happy path: watcher enabled at 200ms — runner exits within 5s of parent death.
 		{
 			const { intermediate, runnerPid } = await spawnDetachedRunner({
-				runnerEntry: runner.path,
+				runnerEntry: runner.entrypoint,
 				parentCheckMs: '200',
 			})
 			try {
@@ -523,7 +551,7 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 		// This proves the watcher (not transport.onclose) is the active mechanism above.
 		{
 			const { intermediate, runnerPid } = await spawnDetachedRunner({
-				runnerEntry: runner.path,
+				runnerEntry: runner.entrypoint,
 				parentCheckMs: '0',
 			})
 			try {
@@ -562,7 +590,7 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 		// Confirms the timer (not some other path) is the only mechanism firing.
 		{
 			const { intermediate, runnerPid } = await spawnDetachedRunner({
-				runnerEntry: runner.path,
+				runnerEntry: runner.entrypoint,
 				parentCheckMs: '10000',
 			})
 			try {

--- a/scripts/smoke/run-smoke.ts
+++ b/scripts/smoke/run-smoke.ts
@@ -13,7 +13,12 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 
 interface RunnerCase {
-	name: 'tsc-runner' | 'bun-runner' | 'biome-runner' | 'claude-hooks'
+	name:
+		| 'tsc-runner'
+		| 'bun-runner'
+		| 'biome-runner'
+		| 'claude-hooks'
+		| 'orphan-detection'
 	entrypoint: string
 	run(sandboxRoot: string): Promise<void>
 }
@@ -352,6 +357,232 @@ async function runBiomeSmoke(sandboxRoot: string): Promise<void> {
 	})
 }
 
+/**
+ * Spawn an intermediate process that itself spawns the runner binary with
+ * fully detached stdio. Returns the intermediate's process handle and the
+ * runner's PID (read from the intermediate's stdout).
+ *
+ * Detached stdio is load-bearing: it ensures killing the intermediate does
+ * not close the runner's stdin, so transport.onclose does not fire and the
+ * watcher is the only mechanism that can trigger shutdown.
+ */
+async function spawnDetachedRunner(args: {
+	runnerEntry: string
+	parentCheckMs: string
+}): Promise<{ intermediate: ReturnType<typeof Bun.spawn>; runnerPid: number }> {
+	const intermediateScript = `
+		const proc = Bun.spawn({
+			cmd: ['bun', process.env.RUNNER_ENTRY],
+			stdio: ['ignore', 'ignore', 'ignore'],
+			env: {
+				...process.env,
+				MCP_PARENT_CHECK_MS: process.env.MCP_PARENT_CHECK_MS,
+			},
+		});
+		process.stdout.write(String(proc.pid) + '\\n');
+		// Idle forever; the parent harness kills this process.
+		setInterval(() => {}, 60_000);
+	`.trim()
+
+	const intermediate = Bun.spawn(['bun', '-e', intermediateScript], {
+		stdout: 'pipe',
+		stderr: 'pipe',
+		env: {
+			...process.env,
+			RUNNER_ENTRY: args.runnerEntry,
+			MCP_PARENT_CHECK_MS: args.parentCheckMs,
+		},
+	})
+
+	const reader = intermediate.stdout.getReader()
+	const decoder = new TextDecoder()
+	let buffer = ''
+	const deadline = Date.now() + 5000
+	let runnerPid: number | undefined
+
+	while (Date.now() < deadline && runnerPid === undefined) {
+		const readPromise = reader.read()
+		const timeoutPromise = new Promise<{ done: true; value?: undefined }>(
+			(resolve) => setTimeout(() => resolve({ done: true }), 500),
+		)
+		const result = (await Promise.race([readPromise, timeoutPromise])) as {
+			done: boolean
+			value?: Uint8Array
+		}
+		if (result.value) {
+			buffer += decoder.decode(result.value)
+			const newlineIdx = buffer.indexOf('\n')
+			if (newlineIdx >= 0) {
+				const candidate = buffer.slice(0, newlineIdx).trim()
+				const parsed = Number(candidate)
+				if (Number.isFinite(parsed) && parsed > 0) {
+					runnerPid = parsed
+					break
+				}
+			}
+		}
+		if (result.done && !result.value) {
+			break
+		}
+	}
+
+	try {
+		reader.releaseLock()
+	} catch {
+		// Ignore: lock release races with intermediate exit.
+	}
+
+	if (runnerPid === undefined) {
+		try {
+			intermediate.kill('SIGKILL')
+		} catch {
+			// Ignore: intermediate may have already exited.
+		}
+		throw new Error('Failed to read runner PID from intermediate process')
+	}
+
+	return { intermediate, runnerPid }
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		// Signal 0 only checks for the existence of the process.
+		process.kill(pid, 0)
+		return true
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code
+		// ESRCH = no such process (definitively dead).
+		// EPERM = exists but no permission (treat as alive — should not happen for our own children).
+		return code === 'EPERM'
+	}
+}
+
+async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs
+	while (Date.now() < deadline) {
+		if (!isProcessAlive(pid)) {
+			return true
+		}
+		await new Promise((resolve) => setTimeout(resolve, 50))
+	}
+	return false
+}
+
+async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
+	const runners = [
+		{
+			name: 'tsc-runner',
+			path: path.join(REPO_ROOT, 'packages/tsc-runner/dist/index.js'),
+		},
+		{
+			name: 'bun-runner',
+			path: path.join(REPO_ROOT, 'packages/bun-runner/dist/index.js'),
+		},
+		{
+			name: 'biome-runner',
+			path: path.join(REPO_ROOT, 'packages/biome-runner/dist/index.js'),
+		},
+	]
+
+	for (const runner of runners) {
+		// Happy path: watcher enabled at 200ms — runner exits within 5s of parent death.
+		{
+			const { intermediate, runnerPid } = await spawnDetachedRunner({
+				runnerEntry: runner.path,
+				parentCheckMs: '200',
+			})
+			try {
+				assert(
+					isProcessAlive(runnerPid),
+					`${runner.name}: runner not alive after spawn`,
+				)
+				intermediate.kill('SIGKILL')
+				const exited = await waitForExit(runnerPid, 5000)
+				assert(
+					exited,
+					`${runner.name}: runner ${runnerPid} did not exit within 5s after parent SIGKILL (watcher should have fired)`,
+				)
+			} finally {
+				if (isProcessAlive(runnerPid)) {
+					try {
+						process.kill(runnerPid, 'SIGKILL')
+					} catch {
+						// Ignore.
+					}
+				}
+				try {
+					intermediate.kill('SIGKILL')
+				} catch {
+					// Ignore.
+				}
+				await intermediate.exited.catch(() => {})
+			}
+		}
+
+		// Negative control: watcher disabled — runner stays alive ≥ 2s after parent dies.
+		// This proves the watcher (not transport.onclose) is the active mechanism above.
+		{
+			const { intermediate, runnerPid } = await spawnDetachedRunner({
+				runnerEntry: runner.path,
+				parentCheckMs: '0',
+			})
+			try {
+				intermediate.kill('SIGKILL')
+				await new Promise((resolve) => setTimeout(resolve, 2000))
+				assert(
+					isProcessAlive(runnerPid),
+					`${runner.name}: with MCP_PARENT_CHECK_MS=0, runner ${runnerPid} unexpectedly exited within 2s — stdin detachment may be leaking and happy-path test is no longer trustworthy`,
+				)
+			} finally {
+				if (isProcessAlive(runnerPid)) {
+					try {
+						process.kill(runnerPid, 'SIGKILL')
+					} catch {
+						// Ignore.
+					}
+				}
+				try {
+					intermediate.kill('SIGKILL')
+				} catch {
+					// Ignore.
+				}
+				await intermediate.exited.catch(() => {})
+			}
+		}
+
+		// Edge case: long interval — runner stays alive within the test window.
+		// Confirms the timer (not some other path) is the only mechanism firing.
+		{
+			const { intermediate, runnerPid } = await spawnDetachedRunner({
+				runnerEntry: runner.path,
+				parentCheckMs: '10000',
+			})
+			try {
+				intermediate.kill('SIGKILL')
+				await new Promise((resolve) => setTimeout(resolve, 1000))
+				assert(
+					isProcessAlive(runnerPid),
+					`${runner.name}: with MCP_PARENT_CHECK_MS=10000, runner ${runnerPid} exited within 1s — interval is not honored`,
+				)
+			} finally {
+				if (isProcessAlive(runnerPid)) {
+					try {
+						process.kill(runnerPid, 'SIGKILL')
+					} catch {
+						// Ignore.
+					}
+				}
+				try {
+					intermediate.kill('SIGKILL')
+				} catch {
+					// Ignore.
+				}
+				await intermediate.exited.catch(() => {})
+			}
+		}
+	}
+}
+
 async function runClaudeHooksSmoke(sandboxRoot: string): Promise<void> {
 	const cacheRoot = path.join(sandboxRoot, 'hooks-cache')
 	await mkdir(cacheRoot, { recursive: true })
@@ -451,6 +682,13 @@ async function run(): Promise<void> {
 			name: 'claude-hooks',
 			entrypoint: path.join(REPO_ROOT, 'packages/claude-hooks/hooks/index.ts'),
 			run: runClaudeHooksSmoke,
+		},
+		{
+			name: 'orphan-detection',
+			// Entrypoint is informational here — the case loops over all three
+			// dist/ binaries internally.
+			entrypoint: path.join(REPO_ROOT, 'packages/bun-runner/dist/index.js'),
+			run: runOrphanDetectionSmoke,
 		},
 	]
 


### PR DESCRIPTION
## Summary

Adds a defensive parent-liveness watcher to all three MCP runners (\`bun-runner\`, \`biome-runner\`, \`tsc-runner\`) so they exit promptly when their parent Claude Code session (or sub-agent) dies without delivering SIGTERM. Closes #56.

Per the issue: each Claude Code session spawns ~4 bun MCP servers, and every sub-agent invocation spawns 4 more. When the parent dies abruptly, runners get reparented to PID 1 and persist indefinitely — a typical workday accumulates 30+ orphaned bun processes.

The watcher polls \`process.ppid\` every 5s (configurable via \`MCP_PARENT_CHECK_MS\`) and routes through the existing \`shutdown()\` path when divergence or PID 1 is detected. It layers additively on top of \`transport.onclose\` + SIGINT/SIGTERM — those primary paths are unchanged. The interval handle is \`unref()\`'d so it never keeps the loop alive on its own.

## What changed

- **3 runner packages** — added \`DEFAULT_PARENT_CHECK_MS\`, \`MIN_PARENT_CHECK_MS\`, \`parseParentCheckMs()\`, \`createParentLivenessWatcher()\`; wired into each \`start*Server()\` after the existing signal handlers.
- **3 test files** — 13 unit tests per package covering env parsing edge cases (default, empty, NaN, zero, negative, clamping) and watcher behavior (disabled / unref / no-fire when ppid unchanged / fire on change / fire on PID 1).
- **\`scripts/smoke/run-smoke.ts\`** — new \`orphan-detection\` smoke case loops over all 3 built \`dist/index.js\` binaries × 3 scenarios (happy path 200ms / negative control disabled / edge case 10s). Negative control proves the watcher (not \`transport.onclose\`) is the active mechanism.
- **Plan doc** — status flipped \`active\` → \`completed\`.
- **Changeset** — patch bump for all three runners.

The watcher logic is duplicated across the three packages by design — repo policy keeps each runner self-contained (\`.claude/CLAUDE.md\`).

## Validation

\`bun run validate\` is green: 142 unit tests + 5 smoke cases. Orphan-detection smoke completes in 10.1s and includes a negative-control gate that fails loudly if stdin-detachment is leaking (which would mask whether the watcher is the actual mechanism).

Manual sanity: built runner binary, killed its parent shell, confirmed exit within ~5s.

## Test plan

- [x] \`bun run validate\` green locally
- [x] Manual: confirm built runner exits within ~5s of parent death
- [ ] CI green (\`pr-quality\`, \`commitlint\`, \`workflow-lint\`, \`package-hygiene\`, \`node-compat\`)
- [ ] Behavior verification on a Claude Code session: orphan count over a workday with sub-agent activity

## Code review notes (deferred follow-ups)

The \`/ce-code-review\` pass surfaced several robustness concerns that were investigated but **deliberately not applied** to this PR. The original watcher works empirically (smoke proves it), but the macOS Bun \`process.ppid\` semantics are subtler than my fixes assumed. Filed as follow-ups for separate diagnosis:

- **\`initialPpid === 1\` foot-gun (P1).** A runner started with \`ppid===1\` already (nohup, Docker as PID 1's child, launchd-spawned) would self-terminate on the first watcher tick because the condition \`current === 1\` is tautologically true. The primary path (Claude Code parent with \`pid > 1\`) is unaffected, but anyone running these runners as published packages outside Claude Code hits it. Attempted fix-then-revert on this branch — needs deeper investigation of why \`process.ppid\` polling actually fires in our happy-path smoke despite my probes showing the value is cached on Bun macOS.
- **\`server.close()\` unguarded rejection (P2).** \`shutdown()\` wraps \`dispose()\` in try/catch but \`server.close()\` is unguarded. A rejection there leaves the runner half-shut-down with \`shuttingDown=true\` so no other path can retry. Pre-existing on the shutdown path; the watcher just adds another caller.
- **Watcher re-fires every tick after detection (P3).** \`onParentDeath\` runs every \`intervalMs\` until \`process.exit\` lands. \`shutdown()\` is idempotent via the \`shuttingDown\` flag, but the lifecycle log line is outside the guard and emits N times. Fix: latch \`onParentDeath\` after first detection, or capture the watcher handle and \`clearInterval\` in \`shutdown()\`.
- **\`MCP_PARENT_CHECK_MS\` undocumented (P3).** Only the changeset and plan reference it. A short \"Environment variables\" section in each package README would help anyone tuning the watcher.
- **Parent-death log below default visibility (P3).** \`lifecycleLogger.info('Parent process gone…')\` falls below the MCP protocol sink default (\`warning\`) and the fingers-crossed flush trigger. Should log at \`warning\` so the event is visible by default.
- **Smoke negative-control variant (P3).** Current test detaches stdin via \`stdio:'ignore'\` (= \`/dev/null\`); a stdin-pipe variant would validate watcher-vs-onclose precedence in production shape.

The two safe test-only improvements from review *did* land in the second commit:
- Smoke negative control now \`await intermediate.exited\` before measuring runner liveness.
- Test comment drift fixed across the three test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parent-process liveness monitoring for runners that triggers graceful shutdown when the parent disappears; polling configurable via MCP_PARENT_CHECK_MS (0 disables; very small intervals are clamped); watcher is non-blocking.

* **Bug Fixes**
  * Hardened shutdown to ensure clean exit even if server close fails.

* **Tests**
  * Added unit and smoke tests covering detection, interval handling, disabled behavior, and cross-runner scenarios.

* **Documentation**
  * Added plan and docs for preventing orphaned runner processes and test strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->