### PR TITLE
fix(runners): add idle shutdown for retained mcp processes

### DIFF
--- a/.changeset/idle-shutdown-retained-runners.md
+++ b/.changeset/idle-shutdown-retained-runners.md
@@ -6,9 +6,11 @@
 
 Add default-on idle shutdown for retained MCP runner processes.
 
-Runners now exit after 15 minutes without tool activity even when an app host
-keeps the parent process and stdio pipes alive. The timeout is configurable via
-`MCP_IDLE_EXIT_MS`, with `0` disabling the idle shutdown backstop.
+Runners now exit after 15 minutes without tracked activity even when an app host
+keeps the parent process and stdio pipes alive. Tracked activity includes tool
+calls and logging-level requests such as `logging/setLevel`. The timeout is
+configurable via `MCP_IDLE_EXIT_MS`, with `0` disabling the idle shutdown
+backstop.
 
 Breaking change: retained clients that relied on an idle runner staying alive
-indefinitely should set `MCP_IDLE_EXIT_MS=0` to preserve the previous behavior.
+indefinitely should set `MCP_IDLE_EXIT_MS=0` to preserve that previous behavior.

--- a/.changeset/idle-shutdown-retained-runners.md
+++ b/.changeset/idle-shutdown-retained-runners.md
@@ -1,0 +1,14 @@
+---
+"@side-quest/biome-runner": major
+"@side-quest/bun-runner": major
+"@side-quest/tsc-runner": major
+---
+
+Add default-on idle shutdown for retained MCP runner processes.
+
+Runners now exit after 15 minutes without tool activity even when an app host
+keeps the parent process and stdio pipes alive. The timeout is configurable via
+`MCP_IDLE_EXIT_MS`, with `0` disabling the idle shutdown backstop.
+
+Breaking change: retained clients that relied on an idle runner staying alive
+indefinitely should set `MCP_IDLE_EXIT_MS=0` to preserve the previous behavior.

--- a/packages/biome-runner/mcp/index.test.ts
+++ b/packages/biome-runner/mcp/index.test.ts
@@ -10,10 +10,15 @@ import {
 	compactLintSummaryForJsonText,
 	createBiomeInvocation,
 	createBiomeServer,
+	createIdleShutdownWatcher,
+	createIdleShutdownWatcherFromEnv,
 	createParentLivenessWatcher,
+	DEFAULT_IDLE_EXIT_MS,
 	DEFAULT_PARENT_CHECK_MS,
+	MIN_IDLE_EXIT_MS,
 	MIN_PARENT_CHECK_MS,
 	parseBiomeOutput,
+	parseIdleExitMs,
 	parseParentCheckMs,
 	SERVER_VERSION,
 	spawnWithTimeout,
@@ -329,6 +334,64 @@ describe('biome tools integration', () => {
 		}
 	})
 
+	test('tool calls and logging/setLevel are tracked as request activity', async () => {
+		_resetGitRootCache()
+		const activityEvents: string[] = []
+		const server = await createBiomeServer({
+			onRequestStart: () => {
+				activityEvents.push('start')
+				return () => activityEvents.push('finish')
+			},
+		})
+		const client = new Client({ name: 'biome-client', version: '0.0.1' })
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+		try {
+			const expectToolActivity = async (name: string, toolArguments: Record<string, unknown>) => {
+				activityEvents.length = 0
+				await client.callTool({
+					name,
+					arguments: toolArguments,
+				})
+				expect(activityEvents).toEqual(['start', 'finish'])
+			}
+
+			// Discovery alone should not keep an abandoned runner alive.
+			await client.listTools()
+			expect(activityEvents).toEqual([])
+
+			await expectToolActivity('biome_lintCheck', {
+				path: '.',
+				response_format: 'json',
+			})
+			await expectToolActivity('biome_formatCheck', {
+				path: '.',
+				response_format: 'json',
+			})
+
+			const fixtureParent = path.join(process.cwd(), 'reports')
+			await mkdir(fixtureParent, { recursive: true })
+			const fixtureDir = await mkdtemp(path.join(fixtureParent, 'biome-activity-fixture-'))
+			try {
+				await writeFile(path.join(fixtureDir, 'bad.js'), 'const foo={bar:1}\n')
+				await expectToolActivity('biome_lintFix', {
+					path: fixtureDir,
+					response_format: 'json',
+				})
+			} finally {
+				await rm(fixtureDir, { recursive: true, force: true })
+			}
+
+			activityEvents.length = 0
+			await client.setLoggingLevel('info')
+			expect(activityEvents).toEqual(['start', 'finish'])
+		} finally {
+			await Promise.all([client.close(), server.close()])
+		}
+	})
+
 	test('format check returns structuredContent', async () => {
 		_resetGitRootCache()
 		const server = await createBiomeServer()
@@ -435,6 +498,207 @@ describe('parseParentCheckMs', () => {
 		expect(parseParentCheckMs('50')).toBe(50)
 		expect(parseParentCheckMs('200')).toBe(200)
 		expect(parseParentCheckMs('5000')).toBe(5000)
+	})
+})
+
+describe('parseIdleExitMs', () => {
+	test('returns default when env is undefined', () => {
+		expect(parseIdleExitMs(undefined)).toBe(DEFAULT_IDLE_EXIT_MS)
+	})
+
+	test('returns default for empty / whitespace string', () => {
+		expect(parseIdleExitMs('')).toBe(DEFAULT_IDLE_EXIT_MS)
+		expect(parseIdleExitMs('   ')).toBe(DEFAULT_IDLE_EXIT_MS)
+	})
+
+	test('returns default for non-numeric / NaN values', () => {
+		expect(parseIdleExitMs('abc')).toBe(DEFAULT_IDLE_EXIT_MS)
+		expect(parseIdleExitMs('NaN')).toBe(DEFAULT_IDLE_EXIT_MS)
+	})
+
+	test('returns 0 (disabled) for zero and negative values', () => {
+		expect(parseIdleExitMs('0')).toBe(0)
+		expect(parseIdleExitMs('-1')).toBe(0)
+	})
+
+	test('clamps tiny positive values up to MIN_IDLE_EXIT_MS', () => {
+		expect(parseIdleExitMs('1')).toBe(MIN_IDLE_EXIT_MS)
+		expect(parseIdleExitMs('49')).toBe(MIN_IDLE_EXIT_MS)
+	})
+
+	test('passes through values at or above the minimum', () => {
+		expect(parseIdleExitMs('50')).toBe(50)
+		expect(parseIdleExitMs('200')).toBe(200)
+		expect(parseIdleExitMs('900000')).toBe(900_000)
+	})
+})
+
+describe('createIdleShutdownWatcherFromEnv', () => {
+	test('uses the default idle timeout when env is omitted', () => {
+		const calls: number[] = []
+		const fakeWatcher = {
+			recordRequestStart: () => () => {},
+			stop: () => {},
+		}
+		const result = createIdleShutdownWatcherFromEnv({
+			env: {},
+			onIdle: () => {},
+			createWatcher: (opts) => {
+				calls.push(opts.idleMs)
+				return fakeWatcher
+			},
+		})
+
+		expect(result.idleMs).toBe(DEFAULT_IDLE_EXIT_MS)
+		expect(result.watcher).toBe(fakeWatcher)
+		expect(calls).toEqual([DEFAULT_IDLE_EXIT_MS])
+	})
+
+	test('passes zero through so the watcher can be disabled', () => {
+		const calls: number[] = []
+		const result = createIdleShutdownWatcherFromEnv({
+			env: { MCP_IDLE_EXIT_MS: '0' },
+			onIdle: () => {},
+			createWatcher: (opts) => {
+				calls.push(opts.idleMs)
+				return undefined
+			},
+		})
+
+		expect(result.idleMs).toBe(0)
+		expect(result.watcher).toBeUndefined()
+		expect(calls).toEqual([0])
+	})
+})
+
+describe('createIdleShutdownWatcher', () => {
+	test('returns undefined when idleMs <= 0 (disabled)', () => {
+		expect(
+			createIdleShutdownWatcher({
+				idleMs: 0,
+				onIdle: () => {
+					throw new Error('should not be called')
+				},
+			}),
+		).toBeUndefined()
+		expect(
+			createIdleShutdownWatcher({
+				idleMs: -1,
+				onIdle: () => {
+					throw new Error('should not be called')
+				},
+			}),
+		).toBeUndefined()
+	})
+
+	test('calls .unref() on the idle timer handle', () => {
+		const probe = setTimeout(() => {}, 60_000)
+		const timerProto = Object.getPrototypeOf(probe) as { unref: () => void }
+		clearTimeout(probe)
+		const unrefSpy = spyOn(timerProto, 'unref')
+		try {
+			const watcher = createIdleShutdownWatcher({
+				idleMs: 60_000,
+				onIdle: () => {
+					throw new Error('should not be called')
+				},
+			})
+			expect(watcher).toBeDefined()
+			expect(unrefSpy).toHaveBeenCalledTimes(1)
+			watcher?.stop()
+		} finally {
+			unrefSpy.mockRestore()
+		}
+	})
+
+	test('invokes onIdle once after inactivity', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 140))
+			expect(calls).toBe(1)
+		} finally {
+			watcher?.stop()
+		}
+	})
+
+	test('does not invoke onIdle while a request is active', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		const finishRequest = watcher?.recordRequestStart()
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 140))
+			expect(calls).toBe(0)
+		} finally {
+			finishRequest?.()
+			watcher?.stop()
+		}
+	})
+
+	test('reschedules idle shutdown after active request finishes', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		const finishRequest = watcher?.recordRequestStart()
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 90))
+			expect(calls).toBe(0)
+			finishRequest?.()
+			await new Promise((resolve) => setTimeout(resolve, 90))
+			expect(calls).toBe(1)
+		} finally {
+			watcher?.stop()
+		}
+	})
+
+	test('waits for all concurrent requests and ignores duplicate finishes', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		const finishFirst = watcher?.recordRequestStart()
+		const finishSecond = watcher?.recordRequestStart()
+		try {
+			finishFirst?.()
+			finishFirst?.()
+			await new Promise((resolve) => setTimeout(resolve, 90))
+			expect(calls).toBe(0)
+			finishSecond?.()
+			await new Promise((resolve) => setTimeout(resolve, 90))
+			expect(calls).toBe(1)
+		} finally {
+			watcher?.stop()
+		}
+	})
+
+	test('stop prevents later idle shutdown', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		watcher?.stop()
+		await new Promise((resolve) => setTimeout(resolve, 120))
+		expect(calls).toBe(0)
 	})
 })
 

--- a/packages/biome-runner/mcp/index.ts
+++ b/packages/biome-runner/mcp/index.ts
@@ -130,6 +130,11 @@ interface ObservabilityState {
 
 interface BiomeServerOptions {
 	stderrStream?: WritableStream
+	onRequestStart?: () => () => void
+}
+
+function startRequestActivity(options?: BiomeServerOptions): () => void {
+	return options?.onRequestStart?.() ?? (() => {})
 }
 
 const lintDiagnosticSchema: z.ZodObject<{
@@ -1010,11 +1015,16 @@ export async function createBiomeServer(
 	server.server.setRequestHandler(
 		SetLevelRequestSchema,
 		async (request): Promise<Record<string, never>> => {
-			observabilityState.clientMcpLogLevel = request.params.level
-			lintCheckLogger.info('Updated MCP logging level', {
-				mcpLevel: request.params.level,
-			})
-			return {}
+			const finishRequest = startRequestActivity(options)
+			try {
+				observabilityState.clientMcpLogLevel = request.params.level
+				lintCheckLogger.info('Updated MCP logging level', {
+					mcpLevel: request.params.level,
+				})
+				return {}
+			} finally {
+				finishRequest()
+			}
 		},
 	)
 
@@ -1047,37 +1057,42 @@ export async function createBiomeServer(
 			},
 		},
 		async (args, extra): Promise<CallToolResult> => {
-			return withContext(
-				{
-					requestId: String(extra.requestId),
-					tool: 'biome_lintCheck',
-				},
-				async () => {
-					try {
-						const validatedPath = await validatePathOrDefault(args.path)
-						await ensurePathExists(validatedPath)
-						const summary = await runBiomeCheck(validatedPath)
-						const format = args.response_format
-						lintCheckLogger.info('biome_lintCheck completed', {
-							path: validatedPath,
-							errorCount: summary.errorCount,
-							warningCount: summary.warningCount,
-						})
-						return createToolSuccess(
-							formatLintSummary(summary, format),
-							summary,
-						)
-					} catch (error) {
-						const failure = toToolFailure(error)
-						lintCheckLogger.error('biome_lintCheck failed', {
-							code: failure.code,
-							message: failure.message,
-							path: args.path ?? null,
-						})
-						return createToolFailure(failure)
-					}
-				},
-			)
+			const finishRequest = startRequestActivity(options)
+			try {
+				return await withContext(
+					{
+						requestId: String(extra.requestId),
+						tool: 'biome_lintCheck',
+					},
+					async () => {
+						try {
+							const validatedPath = await validatePathOrDefault(args.path)
+							await ensurePathExists(validatedPath)
+							const summary = await runBiomeCheck(validatedPath)
+							const format = args.response_format
+							lintCheckLogger.info('biome_lintCheck completed', {
+								path: validatedPath,
+								errorCount: summary.errorCount,
+								warningCount: summary.warningCount,
+							})
+							return createToolSuccess(
+								formatLintSummary(summary, format),
+								summary,
+							)
+						} catch (error) {
+							const failure = toToolFailure(error)
+							lintCheckLogger.error('biome_lintCheck failed', {
+								code: failure.code,
+								message: failure.message,
+								path: args.path ?? null,
+							})
+							return createToolFailure(failure)
+						}
+					},
+				)
+			} finally {
+				finishRequest()
+			}
 		},
 	)
 
@@ -1110,38 +1125,43 @@ export async function createBiomeServer(
 			},
 		},
 		async (args, extra): Promise<CallToolResult> => {
-			return withContext(
-				{
-					requestId: String(extra.requestId),
-					tool: 'biome_lintFix',
-				},
-				async () => {
-					try {
-						const validatedPath = await validatePathOrDefault(args.path)
-						await ensurePathExists(validatedPath)
-						const result = await runBiomeFix(validatedPath)
-						const format = args.response_format
-						lintFixLogger.info('biome_lintFix completed', {
-							path: validatedPath,
-							fixed: result.fixed,
-							remainingErrors: result.remaining.errorCount,
-							remainingWarnings: result.remaining.warningCount,
-						})
-						return createToolSuccess(
-							formatLintFixResult(result, format),
-							result,
-						)
-					} catch (error) {
-						const failure = toToolFailure(error)
-						lintFixLogger.error('biome_lintFix failed', {
-							code: failure.code,
-							message: failure.message,
-							path: args.path ?? null,
-						})
-						return createToolFailure(failure)
-					}
-				},
-			)
+			const finishRequest = startRequestActivity(options)
+			try {
+				return await withContext(
+					{
+						requestId: String(extra.requestId),
+						tool: 'biome_lintFix',
+					},
+					async () => {
+						try {
+							const validatedPath = await validatePathOrDefault(args.path)
+							await ensurePathExists(validatedPath)
+							const result = await runBiomeFix(validatedPath)
+							const format = args.response_format
+							lintFixLogger.info('biome_lintFix completed', {
+								path: validatedPath,
+								fixed: result.fixed,
+								remainingErrors: result.remaining.errorCount,
+								remainingWarnings: result.remaining.warningCount,
+							})
+							return createToolSuccess(
+								formatLintFixResult(result, format),
+								result,
+							)
+						} catch (error) {
+							const failure = toToolFailure(error)
+							lintFixLogger.error('biome_lintFix failed', {
+								code: failure.code,
+								message: failure.message,
+								path: args.path ?? null,
+							})
+							return createToolFailure(failure)
+						}
+					},
+				)
+			} finally {
+				finishRequest()
+			}
 		},
 	)
 
@@ -1174,37 +1194,42 @@ export async function createBiomeServer(
 			},
 		},
 		async (args, extra): Promise<CallToolResult> => {
-			return withContext(
-				{
-					requestId: String(extra.requestId),
-					tool: 'biome_formatCheck',
-				},
-				async () => {
-					try {
-						const validatedPath = await validatePathOrDefault(args.path)
-						await ensurePathExists(validatedPath)
-						const result = await runBiomeFormatCheck(validatedPath)
-						const format = args.response_format
-						formatCheckLogger.info('biome_formatCheck completed', {
-							path: validatedPath,
-							formatted: result.formatted,
-							unformattedCount: result.unformattedFiles.length,
-						})
-						return createToolSuccess(
-							formatFormatCheckResult(result, format),
-							result,
-						)
-					} catch (error) {
-						const failure = toToolFailure(error)
-						formatCheckLogger.error('biome_formatCheck failed', {
-							code: failure.code,
-							message: failure.message,
-							path: args.path ?? null,
-						})
-						return createToolFailure(failure)
-					}
-				},
-			)
+			const finishRequest = startRequestActivity(options)
+			try {
+				return await withContext(
+					{
+						requestId: String(extra.requestId),
+						tool: 'biome_formatCheck',
+					},
+					async () => {
+						try {
+							const validatedPath = await validatePathOrDefault(args.path)
+							await ensurePathExists(validatedPath)
+							const result = await runBiomeFormatCheck(validatedPath)
+							const format = args.response_format
+							formatCheckLogger.info('biome_formatCheck completed', {
+								path: validatedPath,
+								formatted: result.formatted,
+								unformattedCount: result.unformattedFiles.length,
+							})
+							return createToolSuccess(
+								formatFormatCheckResult(result, format),
+								result,
+							)
+						} catch (error) {
+							const failure = toToolFailure(error)
+							formatCheckLogger.error('biome_formatCheck failed', {
+								code: failure.code,
+								message: failure.message,
+								path: args.path ?? null,
+							})
+							return createToolFailure(failure)
+						}
+					},
+				)
+			} finally {
+				finishRequest()
+			}
 		},
 	)
 
@@ -1225,6 +1250,16 @@ export const DEFAULT_PARENT_CHECK_MS = 5000
  * Lower bound for the poll interval to prevent event-loop saturation.
  */
 export const MIN_PARENT_CHECK_MS = 50
+
+/**
+ * Default idle shutdown interval in milliseconds.
+ */
+export const DEFAULT_IDLE_EXIT_MS = 900_000
+
+/**
+ * Lower bound for the idle interval to prevent event-loop saturation.
+ */
+export const MIN_IDLE_EXIT_MS = 50
 
 /**
  * Parse the MCP_PARENT_CHECK_MS env value into a poll interval.
@@ -1248,6 +1283,30 @@ export function parseParentCheckMs(raw: string | undefined): number {
 		return 0
 	}
 	return Math.max(parsed, MIN_PARENT_CHECK_MS)
+}
+
+/**
+ * Parse the MCP_IDLE_EXIT_MS env value into an idle shutdown interval.
+ *
+ * Returns 0 to disable idle shutdown. Otherwise returns the clamped positive
+ * interval. Unparseable / empty / NaN values fall back to the default.
+ */
+export function parseIdleExitMs(raw: string | undefined): number {
+	if (raw === undefined) {
+		return DEFAULT_IDLE_EXIT_MS
+	}
+	const trimmed = raw.trim()
+	if (trimmed === '') {
+		return DEFAULT_IDLE_EXIT_MS
+	}
+	const parsed = Number(trimmed)
+	if (!Number.isFinite(parsed)) {
+		return DEFAULT_IDLE_EXIT_MS
+	}
+	if (parsed <= 0) {
+		return 0
+	}
+	return Math.max(parsed, MIN_IDLE_EXIT_MS)
 }
 
 /**
@@ -1285,6 +1344,109 @@ export function createParentLivenessWatcher(opts: {
 }
 
 /**
+ * Watch for inactivity and invoke onIdle when no tracked activity is in flight.
+ *
+ * This is a backstop for app-hosted clients that keep the parent process and
+ * stdio pipes open after a session is abandoned. Tracked activity currently
+ * covers tool calls and logging/setLevel requests.
+ */
+export function createIdleShutdownWatcher(opts: {
+	idleMs: number
+	onIdle: () => void
+}):
+	| {
+			recordRequestStart: () => () => void
+			stop: () => void
+	  }
+	| undefined {
+	if (opts.idleMs <= 0) {
+		return undefined
+	}
+
+	let activeRequests = 0
+	let stopped = false
+	let handle: ReturnType<typeof setTimeout> | undefined
+
+	const clear = () => {
+		if (handle) {
+			clearTimeout(handle)
+			handle = undefined
+		}
+	}
+
+	const schedule = () => {
+		clear()
+		if (stopped || activeRequests > 0) {
+			return
+		}
+		handle = setTimeout(() => {
+			handle = undefined
+			if (stopped || activeRequests > 0) {
+				return
+			}
+			stopped = true
+			opts.onIdle()
+		}, opts.idleMs)
+		handle.unref()
+	}
+
+	schedule()
+
+	return {
+		recordRequestStart: () => {
+			if (stopped) {
+				return () => {}
+			}
+			activeRequests += 1
+			clear()
+			let finished = false
+			return () => {
+				if (finished) {
+					return
+				}
+				finished = true
+				activeRequests = Math.max(0, activeRequests - 1)
+				schedule()
+			}
+		},
+		stop: () => {
+			stopped = true
+			clear()
+		},
+	}
+}
+
+interface IdleExitEnv {
+	readonly [key: string]: string | undefined
+	MCP_IDLE_EXIT_MS?: string | undefined
+}
+
+/**
+ * Create idle shutdown wiring from process-style environment values.
+ *
+ * Why: startBiomeServer should exercise the same default-on / disabled parsing
+ * as unit tests without making runtime smoke wait for the 15-minute default.
+ */
+export function createIdleShutdownWatcherFromEnv(opts: {
+	env: IdleExitEnv
+	onIdle: (idleMs: number) => void
+	createWatcher?: typeof createIdleShutdownWatcher
+}): {
+	idleMs: number
+	watcher: ReturnType<typeof createIdleShutdownWatcher>
+} {
+	const idleMs = parseIdleExitMs(opts.env.MCP_IDLE_EXIT_MS)
+	const createWatcher = opts.createWatcher ?? createIdleShutdownWatcher
+	return {
+		idleMs,
+		watcher: createWatcher({
+			idleMs,
+			onIdle: () => opts.onIdle(idleMs),
+		}),
+	}
+}
+
+/**
  * Check whether a process exists without sending it a real signal.
  *
  * Why: Bun's process.ppid can retain its startup value after reparenting, so
@@ -1306,7 +1468,10 @@ export async function startBiomeServer(): Promise<void> {
 	// Capture before any await: if the parent dies during async init,
 	// process.ppid reparents to 1 and the original PID is lost.
 	const initialPpid = process.ppid
-	const server = await createBiomeServer()
+	let idleWatcher: ReturnType<typeof createIdleShutdownWatcher> | undefined
+	const server = await createBiomeServer({
+		onRequestStart: () => idleWatcher?.recordRequestStart() ?? (() => {}),
+	})
 	const transport = new StdioServerTransport()
 	let shuttingDown = false
 	const lifecycleLogger = getLogger(['mcp', 'lifecycle'])
@@ -1316,6 +1481,7 @@ export async function startBiomeServer(): Promise<void> {
 			return
 		}
 		shuttingDown = true
+		idleWatcher?.stop()
 		lifecycleLogger.info('Shutting down biome-runner server')
 		try {
 			await dispose()
@@ -1338,6 +1504,17 @@ export async function startBiomeServer(): Promise<void> {
 	transport.onclose = () => {
 		void shutdown()
 	}
+
+	const idleShutdown = createIdleShutdownWatcherFromEnv({
+		env: process.env,
+		onIdle: (idleMs) => {
+			lifecycleLogger.info('Idle timeout reached, shutting down', {
+				idleMs,
+			})
+			void shutdown()
+		},
+	})
+	idleWatcher = idleShutdown.watcher
 
 	await server.connect(transport)
 	lifecycleLogger.info('biome-runner server connected to stdio transport')

--- a/packages/bun-runner/mcp/index.test.ts
+++ b/packages/bun-runner/mcp/index.test.ts
@@ -8,10 +8,15 @@ import {
 	createBunCoverageInvocation,
 	createBunInvocation,
 	createBunServer,
+	createIdleShutdownWatcher,
+	createIdleShutdownWatcherFromEnv,
 	createParentLivenessWatcher,
+	DEFAULT_IDLE_EXIT_MS,
 	DEFAULT_PARENT_CHECK_MS,
 	extractTopStackFrame,
+	MIN_IDLE_EXIT_MS,
 	MIN_PARENT_CHECK_MS,
+	parseIdleExitMs,
 	parseParentCheckMs,
 	SERVER_VERSION,
 	spawnWithTimeout,
@@ -511,6 +516,51 @@ describe('bun tools integration', () => {
 		}
 	})
 
+	test('tool calls and logging/setLevel are tracked as request activity', async () => {
+		_resetGitRootCache()
+		const activityEvents: string[] = []
+		const server = await createBunServer({
+			onRequestStart: () => {
+				activityEvents.push('start')
+				return () => activityEvents.push('finish')
+			},
+		})
+		const client = new Client({ name: 'bun-client', version: '0.0.1' })
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+		try {
+			const expectToolActivity = async (name: string, toolArguments: Record<string, unknown>) => {
+				activityEvents.length = 0
+				await client.callTool({
+					name,
+					arguments: toolArguments,
+				})
+				expect(activityEvents).toEqual(['start', 'finish'])
+			}
+
+			// Discovery alone should not keep an abandoned runner alive.
+			await client.listTools()
+			expect(activityEvents).toEqual([])
+
+			await expectToolActivity('bun_runTests', {
+				pattern: 'nonesuchpattern',
+				response_format: 'json',
+			})
+			await expectToolActivity('bun_testFile', {
+				file: 'definitely-missing.test.ts',
+				response_format: 'json',
+			})
+
+			activityEvents.length = 0
+			await client.setLoggingLevel('info')
+			expect(activityEvents).toEqual(['start', 'finish'])
+		} finally {
+			await Promise.all([client.close(), server.close()])
+		}
+	})
+
 	test('coverage output schema uses uncovered {file, percent} entries', async () => {
 		const server = await createBunServer()
 		const client = new Client({ name: 'bun-client', version: '0.0.1' })
@@ -582,6 +632,207 @@ describe('parseParentCheckMs', () => {
 		expect(parseParentCheckMs('50')).toBe(50)
 		expect(parseParentCheckMs('200')).toBe(200)
 		expect(parseParentCheckMs('5000')).toBe(5000)
+	})
+})
+
+describe('parseIdleExitMs', () => {
+	test('returns default when env is undefined', () => {
+		expect(parseIdleExitMs(undefined)).toBe(DEFAULT_IDLE_EXIT_MS)
+	})
+
+	test('returns default for empty / whitespace string', () => {
+		expect(parseIdleExitMs('')).toBe(DEFAULT_IDLE_EXIT_MS)
+		expect(parseIdleExitMs('   ')).toBe(DEFAULT_IDLE_EXIT_MS)
+	})
+
+	test('returns default for non-numeric / NaN values', () => {
+		expect(parseIdleExitMs('abc')).toBe(DEFAULT_IDLE_EXIT_MS)
+		expect(parseIdleExitMs('NaN')).toBe(DEFAULT_IDLE_EXIT_MS)
+	})
+
+	test('returns 0 (disabled) for zero and negative values', () => {
+		expect(parseIdleExitMs('0')).toBe(0)
+		expect(parseIdleExitMs('-1')).toBe(0)
+	})
+
+	test('clamps tiny positive values up to MIN_IDLE_EXIT_MS', () => {
+		expect(parseIdleExitMs('1')).toBe(MIN_IDLE_EXIT_MS)
+		expect(parseIdleExitMs('49')).toBe(MIN_IDLE_EXIT_MS)
+	})
+
+	test('passes through values at or above the minimum', () => {
+		expect(parseIdleExitMs('50')).toBe(50)
+		expect(parseIdleExitMs('200')).toBe(200)
+		expect(parseIdleExitMs('900000')).toBe(900_000)
+	})
+})
+
+describe('createIdleShutdownWatcherFromEnv', () => {
+	test('uses the default idle timeout when env is omitted', () => {
+		const calls: number[] = []
+		const fakeWatcher = {
+			recordRequestStart: () => () => {},
+			stop: () => {},
+		}
+		const result = createIdleShutdownWatcherFromEnv({
+			env: {},
+			onIdle: () => {},
+			createWatcher: (opts) => {
+				calls.push(opts.idleMs)
+				return fakeWatcher
+			},
+		})
+
+		expect(result.idleMs).toBe(DEFAULT_IDLE_EXIT_MS)
+		expect(result.watcher).toBe(fakeWatcher)
+		expect(calls).toEqual([DEFAULT_IDLE_EXIT_MS])
+	})
+
+	test('passes zero through so the watcher can be disabled', () => {
+		const calls: number[] = []
+		const result = createIdleShutdownWatcherFromEnv({
+			env: { MCP_IDLE_EXIT_MS: '0' },
+			onIdle: () => {},
+			createWatcher: (opts) => {
+				calls.push(opts.idleMs)
+				return undefined
+			},
+		})
+
+		expect(result.idleMs).toBe(0)
+		expect(result.watcher).toBeUndefined()
+		expect(calls).toEqual([0])
+	})
+})
+
+describe('createIdleShutdownWatcher', () => {
+	test('returns undefined when idleMs <= 0 (disabled)', () => {
+		expect(
+			createIdleShutdownWatcher({
+				idleMs: 0,
+				onIdle: () => {
+					throw new Error('should not be called')
+				},
+			}),
+		).toBeUndefined()
+		expect(
+			createIdleShutdownWatcher({
+				idleMs: -1,
+				onIdle: () => {
+					throw new Error('should not be called')
+				},
+			}),
+		).toBeUndefined()
+	})
+
+	test('calls .unref() on the idle timer handle', () => {
+		const probe = setTimeout(() => {}, 60_000)
+		const timerProto = Object.getPrototypeOf(probe) as { unref: () => void }
+		clearTimeout(probe)
+		const unrefSpy = spyOn(timerProto, 'unref')
+		try {
+			const watcher = createIdleShutdownWatcher({
+				idleMs: 60_000,
+				onIdle: () => {
+					throw new Error('should not be called')
+				},
+			})
+			expect(watcher).toBeDefined()
+			expect(unrefSpy).toHaveBeenCalledTimes(1)
+			watcher?.stop()
+		} finally {
+			unrefSpy.mockRestore()
+		}
+	})
+
+	test('invokes onIdle once after inactivity', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 140))
+			expect(calls).toBe(1)
+		} finally {
+			watcher?.stop()
+		}
+	})
+
+	test('does not invoke onIdle while a request is active', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		const finishRequest = watcher?.recordRequestStart()
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 140))
+			expect(calls).toBe(0)
+		} finally {
+			finishRequest?.()
+			watcher?.stop()
+		}
+	})
+
+	test('reschedules idle shutdown after active request finishes', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		const finishRequest = watcher?.recordRequestStart()
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 90))
+			expect(calls).toBe(0)
+			finishRequest?.()
+			await new Promise((resolve) => setTimeout(resolve, 90))
+			expect(calls).toBe(1)
+		} finally {
+			watcher?.stop()
+		}
+	})
+
+	test('waits for all concurrent requests and ignores duplicate finishes', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		const finishFirst = watcher?.recordRequestStart()
+		const finishSecond = watcher?.recordRequestStart()
+		try {
+			finishFirst?.()
+			finishFirst?.()
+			await new Promise((resolve) => setTimeout(resolve, 90))
+			expect(calls).toBe(0)
+			finishSecond?.()
+			await new Promise((resolve) => setTimeout(resolve, 90))
+			expect(calls).toBe(1)
+		} finally {
+			watcher?.stop()
+		}
+	})
+
+	test('stop prevents later idle shutdown', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		watcher?.stop()
+		await new Promise((resolve) => setTimeout(resolve, 120))
+		expect(calls).toBe(0)
 	})
 })
 

--- a/packages/bun-runner/mcp/index.ts
+++ b/packages/bun-runner/mcp/index.ts
@@ -114,6 +114,11 @@ interface ObservabilityState {
 
 interface BunServerOptions {
 	stderrStream?: WritableStream
+	onRequestStart?: () => () => void
+}
+
+function startRequestActivity(options?: BunServerOptions): () => void {
+	return options?.onRequestStart?.() ?? (() => {})
 }
 
 async function collectStreamText(
@@ -941,11 +946,16 @@ export async function createBunServer(
 	server.server.setRequestHandler(
 		SetLevelRequestSchema,
 		async (request): Promise<Record<string, never>> => {
-			observabilityState.clientMcpLogLevel = request.params.level
-			runTestsLogger.info('Updated MCP logging level', {
-				mcpLevel: request.params.level,
-			})
-			return {}
+			const finishRequest = startRequestActivity(options)
+			try {
+				observabilityState.clientMcpLogLevel = request.params.level
+				runTestsLogger.info('Updated MCP logging level', {
+					mcpLevel: request.params.level,
+				})
+				return {}
+			} finally {
+				finishRequest()
+			}
 		},
 	)
 
@@ -978,42 +988,47 @@ export async function createBunServer(
 			},
 		},
 		async (args, extra): Promise<CallToolResult> => {
-			return withContext(
-				{
-					requestId: String(extra.requestId),
-					tool: 'bun_runTests',
-				},
-				async () => {
-					try {
-						const pattern = args.pattern
-						if (pattern) {
-							validateShellSafePattern(pattern)
-							if (pattern.includes('/') || pattern.includes('..')) {
-								await validatePath(pattern)
+			const finishRequest = startRequestActivity(options)
+			try {
+				return await withContext(
+					{
+						requestId: String(extra.requestId),
+						tool: 'bun_runTests',
+					},
+					async () => {
+						try {
+							const pattern = args.pattern
+							if (pattern) {
+								validateShellSafePattern(pattern)
+								if (pattern.includes('/') || pattern.includes('..')) {
+									await validatePath(pattern)
+								}
 							}
-						}
 
-						const summary = await runBunTests(pattern)
-						const format = args.response_format ?? 'json'
-						runTestsLogger.info('bun_runTests completed', {
-							passed: summary.passed,
-							failed: summary.failed,
-							total: summary.total,
-						})
-						return createToolSuccess(
-							formatTestSummary(summary, format),
-							summary,
-						)
-					} catch (error) {
-						const failure = toToolFailure(error)
-						runTestsLogger.error('bun_runTests failed', {
-							code: failure.code,
-							message: failure.message,
-						})
-						return createToolFailure(failure)
-					}
-				},
-			)
+							const summary = await runBunTests(pattern)
+							const format = args.response_format ?? 'json'
+							runTestsLogger.info('bun_runTests completed', {
+								passed: summary.passed,
+								failed: summary.failed,
+								total: summary.total,
+							})
+							return createToolSuccess(
+								formatTestSummary(summary, format),
+								summary,
+							)
+						} catch (error) {
+							const failure = toToolFailure(error)
+							runTestsLogger.error('bun_runTests failed', {
+								code: failure.code,
+								message: failure.message,
+							})
+							return createToolFailure(failure)
+						}
+					},
+				)
+			} finally {
+				finishRequest()
+			}
 		},
 	)
 
@@ -1043,36 +1058,41 @@ export async function createBunServer(
 			},
 		},
 		async (args, extra): Promise<CallToolResult> => {
-			return withContext(
-				{
-					requestId: String(extra.requestId),
-					tool: 'bun_testFile',
-				},
-				async () => {
-					try {
-						const validatedFile = await validatePath(args.file)
-						const summary = await runBunTests(validatedFile)
-						const format = args.response_format ?? 'json'
-						testFileLogger.info('bun_testFile completed', {
-							file: args.file,
-							passed: summary.passed,
-							failed: summary.failed,
-						})
-						return createToolSuccess(
-							formatTestSummary(summary, format, args.file),
-							summary,
-						)
-					} catch (error) {
-						const failure = toToolFailure(error)
-						testFileLogger.error('bun_testFile failed', {
-							code: failure.code,
-							message: failure.message,
-							file: args.file,
-						})
-						return createToolFailure(failure)
-					}
-				},
-			)
+			const finishRequest = startRequestActivity(options)
+			try {
+				return await withContext(
+					{
+						requestId: String(extra.requestId),
+						tool: 'bun_testFile',
+					},
+					async () => {
+						try {
+							const validatedFile = await validatePath(args.file)
+							const summary = await runBunTests(validatedFile)
+							const format = args.response_format ?? 'json'
+							testFileLogger.info('bun_testFile completed', {
+								file: args.file,
+								passed: summary.passed,
+								failed: summary.failed,
+							})
+							return createToolSuccess(
+								formatTestSummary(summary, format, args.file),
+								summary,
+							)
+						} catch (error) {
+							const failure = toToolFailure(error)
+							testFileLogger.error('bun_testFile failed', {
+								code: failure.code,
+								message: failure.message,
+								file: args.file,
+							})
+							return createToolFailure(failure)
+						}
+					},
+				)
+			} finally {
+				finishRequest()
+			}
 		},
 	)
 
@@ -1098,34 +1118,39 @@ export async function createBunServer(
 			},
 		},
 		async (args, extra): Promise<CallToolResult> => {
-			return withContext(
-				{
-					requestId: String(extra.requestId),
-					tool: 'bun_testCoverage',
-				},
-				async () => {
-					try {
-						const result = await runBunTestCoverage()
-						const format = args.response_format ?? 'json'
-						coverageLogger.info('bun_testCoverage completed', {
-							failed: result.summary.failed,
-							passed: result.summary.passed,
-							coveragePercent: result.coverage.percent,
-						})
-						return createToolSuccess(
-							formatCoverageResult(result, format),
-							result,
-						)
-					} catch (error) {
-						const failure = toToolFailure(error)
-						coverageLogger.error('bun_testCoverage failed', {
-							code: failure.code,
-							message: failure.message,
-						})
-						return createToolFailure(failure)
-					}
-				},
-			)
+			const finishRequest = startRequestActivity(options)
+			try {
+				return await withContext(
+					{
+						requestId: String(extra.requestId),
+						tool: 'bun_testCoverage',
+					},
+					async () => {
+						try {
+							const result = await runBunTestCoverage()
+							const format = args.response_format ?? 'json'
+							coverageLogger.info('bun_testCoverage completed', {
+								failed: result.summary.failed,
+								passed: result.summary.passed,
+								coveragePercent: result.coverage.percent,
+							})
+							return createToolSuccess(
+								formatCoverageResult(result, format),
+								result,
+							)
+						} catch (error) {
+							const failure = toToolFailure(error)
+							coverageLogger.error('bun_testCoverage failed', {
+								code: failure.code,
+								message: failure.message,
+							})
+							return createToolFailure(failure)
+						}
+					},
+				)
+			} finally {
+				finishRequest()
+			}
 		},
 	)
 
@@ -1146,6 +1171,16 @@ export const DEFAULT_PARENT_CHECK_MS = 5000
  * Lower bound for the poll interval to prevent event-loop saturation.
  */
 export const MIN_PARENT_CHECK_MS = 50
+
+/**
+ * Default idle shutdown interval in milliseconds.
+ */
+export const DEFAULT_IDLE_EXIT_MS = 900_000
+
+/**
+ * Lower bound for the idle interval to prevent event-loop saturation.
+ */
+export const MIN_IDLE_EXIT_MS = 50
 
 /**
  * Parse the MCP_PARENT_CHECK_MS env value into a poll interval.
@@ -1169,6 +1204,30 @@ export function parseParentCheckMs(raw: string | undefined): number {
 		return 0
 	}
 	return Math.max(parsed, MIN_PARENT_CHECK_MS)
+}
+
+/**
+ * Parse the MCP_IDLE_EXIT_MS env value into an idle shutdown interval.
+ *
+ * Returns 0 to disable idle shutdown. Otherwise returns the clamped positive
+ * interval. Unparseable / empty / NaN values fall back to the default.
+ */
+export function parseIdleExitMs(raw: string | undefined): number {
+	if (raw === undefined) {
+		return DEFAULT_IDLE_EXIT_MS
+	}
+	const trimmed = raw.trim()
+	if (trimmed === '') {
+		return DEFAULT_IDLE_EXIT_MS
+	}
+	const parsed = Number(trimmed)
+	if (!Number.isFinite(parsed)) {
+		return DEFAULT_IDLE_EXIT_MS
+	}
+	if (parsed <= 0) {
+		return 0
+	}
+	return Math.max(parsed, MIN_IDLE_EXIT_MS)
 }
 
 /**
@@ -1206,6 +1265,109 @@ export function createParentLivenessWatcher(opts: {
 }
 
 /**
+ * Watch for inactivity and invoke onIdle when no tracked activity is in flight.
+ *
+ * This is a backstop for app-hosted clients that keep the parent process and
+ * stdio pipes open after a session is abandoned. Tracked activity currently
+ * covers tool calls and logging/setLevel requests.
+ */
+export function createIdleShutdownWatcher(opts: {
+	idleMs: number
+	onIdle: () => void
+}):
+	| {
+			recordRequestStart: () => () => void
+			stop: () => void
+	  }
+	| undefined {
+	if (opts.idleMs <= 0) {
+		return undefined
+	}
+
+	let activeRequests = 0
+	let stopped = false
+	let handle: ReturnType<typeof setTimeout> | undefined
+
+	const clear = () => {
+		if (handle) {
+			clearTimeout(handle)
+			handle = undefined
+		}
+	}
+
+	const schedule = () => {
+		clear()
+		if (stopped || activeRequests > 0) {
+			return
+		}
+		handle = setTimeout(() => {
+			handle = undefined
+			if (stopped || activeRequests > 0) {
+				return
+			}
+			stopped = true
+			opts.onIdle()
+		}, opts.idleMs)
+		handle.unref()
+	}
+
+	schedule()
+
+	return {
+		recordRequestStart: () => {
+			if (stopped) {
+				return () => {}
+			}
+			activeRequests += 1
+			clear()
+			let finished = false
+			return () => {
+				if (finished) {
+					return
+				}
+				finished = true
+				activeRequests = Math.max(0, activeRequests - 1)
+				schedule()
+			}
+		},
+		stop: () => {
+			stopped = true
+			clear()
+		},
+	}
+}
+
+interface IdleExitEnv {
+	readonly [key: string]: string | undefined
+	MCP_IDLE_EXIT_MS?: string | undefined
+}
+
+/**
+ * Create idle shutdown wiring from process-style environment values.
+ *
+ * Why: startBunServer should exercise the same default-on / disabled parsing
+ * as unit tests without making runtime smoke wait for the 15-minute default.
+ */
+export function createIdleShutdownWatcherFromEnv(opts: {
+	env: IdleExitEnv
+	onIdle: (idleMs: number) => void
+	createWatcher?: typeof createIdleShutdownWatcher
+}): {
+	idleMs: number
+	watcher: ReturnType<typeof createIdleShutdownWatcher>
+} {
+	const idleMs = parseIdleExitMs(opts.env.MCP_IDLE_EXIT_MS)
+	const createWatcher = opts.createWatcher ?? createIdleShutdownWatcher
+	return {
+		idleMs,
+		watcher: createWatcher({
+			idleMs,
+			onIdle: () => opts.onIdle(idleMs),
+		}),
+	}
+}
+
+/**
  * Check whether a process exists without sending it a real signal.
  *
  * Why: Bun's process.ppid can retain its startup value after reparenting, so
@@ -1227,7 +1389,10 @@ export async function startBunServer(): Promise<void> {
 	// Capture before any await: if the parent dies during async init,
 	// process.ppid reparents to 1 and the original PID is lost.
 	const initialPpid = process.ppid
-	const server = await createBunServer()
+	let idleWatcher: ReturnType<typeof createIdleShutdownWatcher> | undefined
+	const server = await createBunServer({
+		onRequestStart: () => idleWatcher?.recordRequestStart() ?? (() => {}),
+	})
 	const transport = new StdioServerTransport()
 	let shuttingDown = false
 	const lifecycleLogger = getLogger(['mcp', 'lifecycle'])
@@ -1237,6 +1402,7 @@ export async function startBunServer(): Promise<void> {
 			return
 		}
 		shuttingDown = true
+		idleWatcher?.stop()
 		lifecycleLogger.info('Shutting down bun-runner server')
 		try {
 			await dispose()
@@ -1259,6 +1425,17 @@ export async function startBunServer(): Promise<void> {
 	transport.onclose = () => {
 		void shutdown()
 	}
+
+	const idleShutdown = createIdleShutdownWatcherFromEnv({
+		env: process.env,
+		onIdle: (idleMs) => {
+			lifecycleLogger.info('Idle timeout reached, shutting down', {
+				idleMs,
+			})
+			void shutdown()
+		},
+	})
+	idleWatcher = idleShutdown.watcher
 
 	await server.connect(transport)
 	lifecycleLogger.info('bun-runner server connected to stdio transport')

--- a/packages/tsc-runner/mcp/index.test.ts
+++ b/packages/tsc-runner/mcp/index.test.ts
@@ -9,13 +9,18 @@ import {
 	_resetGitRootCache,
 	buildTscOutput,
 	compactTscOutputForJsonText,
+	createIdleShutdownWatcher,
+	createIdleShutdownWatcherFromEnv,
 	createParentLivenessWatcher,
 	createTscInvocation,
 	createTscServer,
+	DEFAULT_IDLE_EXIT_MS,
 	DEFAULT_PARENT_CHECK_MS,
 	detectTsBuildInfoCorruption,
 	formatTscMarkdown,
+	MIN_IDLE_EXIT_MS,
 	MIN_PARENT_CHECK_MS,
+	parseIdleExitMs,
 	parseParentCheckMs,
 	parseTscOutput,
 	SERVER_VERSION,
@@ -425,6 +430,42 @@ describe('tsc_check integration', () => {
 		}
 	})
 
+	test('tool calls and logging/setLevel are tracked as request activity', async () => {
+		_resetGitRootCache()
+		const activityEvents: string[] = []
+		const server = await createTscServer({
+			onRequestStart: () => {
+				activityEvents.push('start')
+				return () => activityEvents.push('finish')
+			},
+		})
+		const client = new Client({ name: 'tsc-client', version: '0.0.1' })
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+		try {
+			// Discovery alone should not keep an abandoned runner alive.
+			await client.listTools()
+			expect(activityEvents).toEqual([])
+
+			await client.callTool({
+				name: 'tsc_check',
+				arguments: {
+					path: '.',
+					response_format: 'json',
+				},
+			})
+			expect(activityEvents).toEqual(['start', 'finish'])
+
+			activityEvents.length = 0
+			await client.setLoggingLevel('info')
+			expect(activityEvents).toEqual(['start', 'finish'])
+		} finally {
+			await Promise.all([client.close(), server.close()])
+		}
+	})
+
 	test('returns PATH_NOT_FOUND for unknown paths', async () => {
 		_resetGitRootCache()
 		const stderrChunks: string[] = []
@@ -614,6 +655,207 @@ describe('parseParentCheckMs', () => {
 		expect(parseParentCheckMs('50')).toBe(50)
 		expect(parseParentCheckMs('200')).toBe(200)
 		expect(parseParentCheckMs('5000')).toBe(5000)
+	})
+})
+
+describe('parseIdleExitMs', () => {
+	test('returns default when env is undefined', () => {
+		expect(parseIdleExitMs(undefined)).toBe(DEFAULT_IDLE_EXIT_MS)
+	})
+
+	test('returns default for empty / whitespace string', () => {
+		expect(parseIdleExitMs('')).toBe(DEFAULT_IDLE_EXIT_MS)
+		expect(parseIdleExitMs('   ')).toBe(DEFAULT_IDLE_EXIT_MS)
+	})
+
+	test('returns default for non-numeric / NaN values', () => {
+		expect(parseIdleExitMs('abc')).toBe(DEFAULT_IDLE_EXIT_MS)
+		expect(parseIdleExitMs('NaN')).toBe(DEFAULT_IDLE_EXIT_MS)
+	})
+
+	test('returns 0 (disabled) for zero and negative values', () => {
+		expect(parseIdleExitMs('0')).toBe(0)
+		expect(parseIdleExitMs('-1')).toBe(0)
+	})
+
+	test('clamps tiny positive values up to MIN_IDLE_EXIT_MS', () => {
+		expect(parseIdleExitMs('1')).toBe(MIN_IDLE_EXIT_MS)
+		expect(parseIdleExitMs('49')).toBe(MIN_IDLE_EXIT_MS)
+	})
+
+	test('passes through values at or above the minimum', () => {
+		expect(parseIdleExitMs('50')).toBe(50)
+		expect(parseIdleExitMs('200')).toBe(200)
+		expect(parseIdleExitMs('900000')).toBe(900_000)
+	})
+})
+
+describe('createIdleShutdownWatcherFromEnv', () => {
+	test('uses the default idle timeout when env is omitted', () => {
+		const calls: number[] = []
+		const fakeWatcher = {
+			recordRequestStart: () => () => {},
+			stop: () => {},
+		}
+		const result = createIdleShutdownWatcherFromEnv({
+			env: {},
+			onIdle: () => {},
+			createWatcher: (opts) => {
+				calls.push(opts.idleMs)
+				return fakeWatcher
+			},
+		})
+
+		expect(result.idleMs).toBe(DEFAULT_IDLE_EXIT_MS)
+		expect(result.watcher).toBe(fakeWatcher)
+		expect(calls).toEqual([DEFAULT_IDLE_EXIT_MS])
+	})
+
+	test('passes zero through so the watcher can be disabled', () => {
+		const calls: number[] = []
+		const result = createIdleShutdownWatcherFromEnv({
+			env: { MCP_IDLE_EXIT_MS: '0' },
+			onIdle: () => {},
+			createWatcher: (opts) => {
+				calls.push(opts.idleMs)
+				return undefined
+			},
+		})
+
+		expect(result.idleMs).toBe(0)
+		expect(result.watcher).toBeUndefined()
+		expect(calls).toEqual([0])
+	})
+})
+
+describe('createIdleShutdownWatcher', () => {
+	test('returns undefined when idleMs <= 0 (disabled)', () => {
+		expect(
+			createIdleShutdownWatcher({
+				idleMs: 0,
+				onIdle: () => {
+					throw new Error('should not be called')
+				},
+			}),
+		).toBeUndefined()
+		expect(
+			createIdleShutdownWatcher({
+				idleMs: -1,
+				onIdle: () => {
+					throw new Error('should not be called')
+				},
+			}),
+		).toBeUndefined()
+	})
+
+	test('calls .unref() on the idle timer handle', () => {
+		const probe = setTimeout(() => {}, 60_000)
+		const timerProto = Object.getPrototypeOf(probe) as { unref: () => void }
+		clearTimeout(probe)
+		const unrefSpy = spyOn(timerProto, 'unref')
+		try {
+			const watcher = createIdleShutdownWatcher({
+				idleMs: 60_000,
+				onIdle: () => {
+					throw new Error('should not be called')
+				},
+			})
+			expect(watcher).toBeDefined()
+			expect(unrefSpy).toHaveBeenCalledTimes(1)
+			watcher?.stop()
+		} finally {
+			unrefSpy.mockRestore()
+		}
+	})
+
+	test('invokes onIdle once after inactivity', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 140))
+			expect(calls).toBe(1)
+		} finally {
+			watcher?.stop()
+		}
+	})
+
+	test('does not invoke onIdle while a request is active', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		const finishRequest = watcher?.recordRequestStart()
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 140))
+			expect(calls).toBe(0)
+		} finally {
+			finishRequest?.()
+			watcher?.stop()
+		}
+	})
+
+	test('reschedules idle shutdown after active request finishes', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		const finishRequest = watcher?.recordRequestStart()
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 90))
+			expect(calls).toBe(0)
+			finishRequest?.()
+			await new Promise((resolve) => setTimeout(resolve, 90))
+			expect(calls).toBe(1)
+		} finally {
+			watcher?.stop()
+		}
+	})
+
+	test('waits for all concurrent requests and ignores duplicate finishes', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		const finishFirst = watcher?.recordRequestStart()
+		const finishSecond = watcher?.recordRequestStart()
+		try {
+			finishFirst?.()
+			finishFirst?.()
+			await new Promise((resolve) => setTimeout(resolve, 90))
+			expect(calls).toBe(0)
+			finishSecond?.()
+			await new Promise((resolve) => setTimeout(resolve, 90))
+			expect(calls).toBe(1)
+		} finally {
+			watcher?.stop()
+		}
+	})
+
+	test('stop prevents later idle shutdown', async () => {
+		let calls = 0
+		const watcher = createIdleShutdownWatcher({
+			idleMs: 50,
+			onIdle: () => {
+				calls += 1
+			},
+		})
+		watcher?.stop()
+		await new Promise((resolve) => setTimeout(resolve, 120))
+		expect(calls).toBe(0)
 	})
 })
 

--- a/packages/tsc-runner/mcp/index.ts
+++ b/packages/tsc-runner/mcp/index.ts
@@ -204,6 +204,11 @@ interface ObservabilityState {
 
 interface TscServerOptions {
 	stderrStream?: WritableStream
+	onRequestStart?: () => () => void
+}
+
+function startRequestActivity(options?: TscServerOptions): () => void {
+	return options?.onRequestStart?.() ?? (() => {})
 }
 
 /**
@@ -972,11 +977,16 @@ export async function createTscServer(
 	server.server.setRequestHandler(
 		SetLevelRequestSchema,
 		async (request): Promise<Record<string, never>> => {
-			observabilityState.clientMcpLogLevel = request.params.level
-			toolLogger.info('Updated MCP logging level', {
-				mcpLevel: request.params.level,
-			})
-			return {}
+			const finishRequest = startRequestActivity(options)
+			try {
+				observabilityState.clientMcpLogLevel = request.params.level
+				toolLogger.info('Updated MCP logging level', {
+					mcpLevel: request.params.level,
+				})
+				return {}
+			} finally {
+				finishRequest()
+			}
 		},
 	)
 
@@ -1009,88 +1019,96 @@ export async function createTscServer(
 			},
 		},
 		async (args, extra): Promise<CallToolResult> => {
-			return withContext(
-				{
-					requestId: String(extra.requestId),
-					tool: 'tsc_check',
-				},
-				async () => {
-					toolLogger.debug('Received tsc_check call', {
-						path: args.path ?? null,
-						responseFormat: args.response_format ?? 'json',
-					})
-
-					try {
-						const { cwd, configPath } = await resolveWorkdir(args.path)
-						const output = await runTsc(cwd, configPath)
-						const format = args.response_format ?? 'json'
-
-						const text =
-							format === 'json'
-								? JSON.stringify(compactTscOutputForJsonText(output))
-								: output.exitCode === 0 || output.errorCount === 0
-									? `TypeScript passed (cwd: ${output.cwd})`
-									: formatTscMarkdown(output)
-
-						toolLogger.info('tsc_check completed', {
-							cwd: output.cwd,
-							configPath: output.configPath,
-							exitCode: output.exitCode,
-							errorCount: output.errorCount,
+			const finishRequest = startRequestActivity(options)
+			try {
+				return await withContext(
+					{
+						requestId: String(extra.requestId),
+						tool: 'tsc_check',
+					},
+					async () => {
+						toolLogger.debug('Received tsc_check call', {
+							path: args.path ?? null,
+							responseFormat: args.response_format ?? 'json',
 						})
 
-						return {
-							isError: false,
-							content: [{ type: 'text', text }],
-							structuredContent: toStructured(
-								stripNullishDeep(output) as unknown as Record<string, unknown>,
-							),
+						try {
+							const { cwd, configPath } = await resolveWorkdir(args.path)
+							const output = await runTsc(cwd, configPath)
+							const format = args.response_format ?? 'json'
+
+							const text =
+								format === 'json'
+									? JSON.stringify(compactTscOutputForJsonText(output))
+									: output.exitCode === 0 || output.errorCount === 0
+										? `TypeScript passed (cwd: ${output.cwd})`
+										: formatTscMarkdown(output)
+
+							toolLogger.info('tsc_check completed', {
+								cwd: output.cwd,
+								configPath: output.configPath,
+								exitCode: output.exitCode,
+								errorCount: output.errorCount,
+							})
+
+							return {
+								isError: false,
+								content: [{ type: 'text', text }],
+								structuredContent: toStructured(
+									stripNullishDeep(output) as unknown as Record<
+										string,
+										unknown
+									>,
+								),
+							}
+						} catch (error) {
+							const failure = toToolFailure(error)
+							const failureOutput: TscOutput = {
+								cwd: process.cwd(),
+								configPath: '',
+								timedOut: failure.code === 'TIMEOUT',
+								exitCode: 1,
+								errors: [
+									{
+										file: '',
+										line: 1,
+										col: 1,
+										code: failure.code,
+										message: failure.message,
+									},
+								],
+								errorCount: 1,
+								remediationHint: failure.remediationHint,
+								parseWarning:
+									'Tool failed before compiler diagnostics could be produced.',
+								rawStderr: failure.message,
+							}
+							toolLogger.error('tsc_check failed', {
+								code: failure.code,
+								message: failure.message,
+								remediationHint: failure.remediationHint ?? null,
+							})
+							return {
+								isError: true,
+								content: [
+									{
+										type: 'text',
+										text: `${failure.code}: ${failure.message}${failure.remediationHint ? `\n${failure.remediationHint}` : ''}`,
+									},
+								],
+								structuredContent: toStructured(
+									stripNullishDeep(failureOutput) as unknown as Record<
+										string,
+										unknown
+									>,
+								),
+							}
 						}
-					} catch (error) {
-						const failure = toToolFailure(error)
-						const failureOutput: TscOutput = {
-							cwd: process.cwd(),
-							configPath: '',
-							timedOut: failure.code === 'TIMEOUT',
-							exitCode: 1,
-							errors: [
-								{
-									file: '',
-									line: 1,
-									col: 1,
-									code: failure.code,
-									message: failure.message,
-								},
-							],
-							errorCount: 1,
-							remediationHint: failure.remediationHint,
-							parseWarning:
-								'Tool failed before compiler diagnostics could be produced.',
-							rawStderr: failure.message,
-						}
-						toolLogger.error('tsc_check failed', {
-							code: failure.code,
-							message: failure.message,
-							remediationHint: failure.remediationHint ?? null,
-						})
-						return {
-							isError: true,
-							content: [
-								{
-									type: 'text',
-									text: `${failure.code}: ${failure.message}${failure.remediationHint ? `\n${failure.remediationHint}` : ''}`,
-								},
-							],
-							structuredContent: toStructured(
-								stripNullishDeep(failureOutput) as unknown as Record<
-									string,
-									unknown
-								>,
-							),
-						}
-					}
-				},
-			)
+					},
+				)
+			} finally {
+				finishRequest()
+			}
 		},
 	)
 
@@ -1111,6 +1129,16 @@ export const DEFAULT_PARENT_CHECK_MS = 5000
  * Lower bound for the poll interval to prevent event-loop saturation.
  */
 export const MIN_PARENT_CHECK_MS = 50
+
+/**
+ * Default idle shutdown interval in milliseconds.
+ */
+export const DEFAULT_IDLE_EXIT_MS = 900_000
+
+/**
+ * Lower bound for the idle interval to prevent event-loop saturation.
+ */
+export const MIN_IDLE_EXIT_MS = 50
 
 /**
  * Parse the MCP_PARENT_CHECK_MS env value into a poll interval.
@@ -1134,6 +1162,30 @@ export function parseParentCheckMs(raw: string | undefined): number {
 		return 0
 	}
 	return Math.max(parsed, MIN_PARENT_CHECK_MS)
+}
+
+/**
+ * Parse the MCP_IDLE_EXIT_MS env value into an idle shutdown interval.
+ *
+ * Returns 0 to disable idle shutdown. Otherwise returns the clamped positive
+ * interval. Unparseable / empty / NaN values fall back to the default.
+ */
+export function parseIdleExitMs(raw: string | undefined): number {
+	if (raw === undefined) {
+		return DEFAULT_IDLE_EXIT_MS
+	}
+	const trimmed = raw.trim()
+	if (trimmed === '') {
+		return DEFAULT_IDLE_EXIT_MS
+	}
+	const parsed = Number(trimmed)
+	if (!Number.isFinite(parsed)) {
+		return DEFAULT_IDLE_EXIT_MS
+	}
+	if (parsed <= 0) {
+		return 0
+	}
+	return Math.max(parsed, MIN_IDLE_EXIT_MS)
 }
 
 /**
@@ -1171,6 +1223,109 @@ export function createParentLivenessWatcher(opts: {
 }
 
 /**
+ * Watch for inactivity and invoke onIdle when no tracked activity is in flight.
+ *
+ * This is a backstop for app-hosted clients that keep the parent process and
+ * stdio pipes open after a session is abandoned. Tracked activity currently
+ * covers tool calls and logging/setLevel requests.
+ */
+export function createIdleShutdownWatcher(opts: {
+	idleMs: number
+	onIdle: () => void
+}):
+	| {
+			recordRequestStart: () => () => void
+			stop: () => void
+	  }
+	| undefined {
+	if (opts.idleMs <= 0) {
+		return undefined
+	}
+
+	let activeRequests = 0
+	let stopped = false
+	let handle: ReturnType<typeof setTimeout> | undefined
+
+	const clear = () => {
+		if (handle) {
+			clearTimeout(handle)
+			handle = undefined
+		}
+	}
+
+	const schedule = () => {
+		clear()
+		if (stopped || activeRequests > 0) {
+			return
+		}
+		handle = setTimeout(() => {
+			handle = undefined
+			if (stopped || activeRequests > 0) {
+				return
+			}
+			stopped = true
+			opts.onIdle()
+		}, opts.idleMs)
+		handle.unref()
+	}
+
+	schedule()
+
+	return {
+		recordRequestStart: () => {
+			if (stopped) {
+				return () => {}
+			}
+			activeRequests += 1
+			clear()
+			let finished = false
+			return () => {
+				if (finished) {
+					return
+				}
+				finished = true
+				activeRequests = Math.max(0, activeRequests - 1)
+				schedule()
+			}
+		},
+		stop: () => {
+			stopped = true
+			clear()
+		},
+	}
+}
+
+interface IdleExitEnv {
+	readonly [key: string]: string | undefined
+	MCP_IDLE_EXIT_MS?: string | undefined
+}
+
+/**
+ * Create idle shutdown wiring from process-style environment values.
+ *
+ * Why: startTscServer should exercise the same default-on / disabled parsing
+ * as unit tests without making runtime smoke wait for the 15-minute default.
+ */
+export function createIdleShutdownWatcherFromEnv(opts: {
+	env: IdleExitEnv
+	onIdle: (idleMs: number) => void
+	createWatcher?: typeof createIdleShutdownWatcher
+}): {
+	idleMs: number
+	watcher: ReturnType<typeof createIdleShutdownWatcher>
+} {
+	const idleMs = parseIdleExitMs(opts.env.MCP_IDLE_EXIT_MS)
+	const createWatcher = opts.createWatcher ?? createIdleShutdownWatcher
+	return {
+		idleMs,
+		watcher: createWatcher({
+			idleMs,
+			onIdle: () => opts.onIdle(idleMs),
+		}),
+	}
+}
+
+/**
  * Check whether a process exists without sending it a real signal.
  *
  * Why: Bun's process.ppid can retain its startup value after reparenting, so
@@ -1194,7 +1349,10 @@ export async function startTscServer(): Promise<void> {
 	// Capture before any await: if the parent dies during async init,
 	// process.ppid reparents to 1 and the original PID is lost.
 	const initialPpid = process.ppid
-	const server = await createTscServer()
+	let idleWatcher: ReturnType<typeof createIdleShutdownWatcher> | undefined
+	const server = await createTscServer({
+		onRequestStart: () => idleWatcher?.recordRequestStart() ?? (() => {}),
+	})
 	const transport = new StdioServerTransport()
 	let shuttingDown = false
 	const lifecycleLogger = getLogger(['mcp', 'lifecycle'])
@@ -1204,6 +1362,7 @@ export async function startTscServer(): Promise<void> {
 			return
 		}
 		shuttingDown = true
+		idleWatcher?.stop()
 		lifecycleLogger.info('Shutting down tsc-runner server')
 		try {
 			await dispose()
@@ -1226,6 +1385,17 @@ export async function startTscServer(): Promise<void> {
 	transport.onclose = () => {
 		void shutdown()
 	}
+
+	const idleShutdown = createIdleShutdownWatcherFromEnv({
+		env: process.env,
+		onIdle: (idleMs) => {
+			lifecycleLogger.info('Idle timeout reached, shutting down', {
+				idleMs,
+			})
+			void shutdown()
+		},
+	})
+	idleWatcher = idleShutdown.watcher
 
 	await server.connect(transport)
 	lifecycleLogger.info('tsc-runner server connected to stdio transport')

--- a/scripts/smoke/run-smoke.ts
+++ b/scripts/smoke/run-smoke.ts
@@ -46,9 +46,9 @@ interface ProductionRunnerBinary {
 const REPO_ROOT = path.resolve(import.meta.dir, '..', '..')
 const TOOL_TIMEOUT_MS = 15_000
 const ORPHAN_RUNNER_STARTUP_SETTLE_MS = 500
-const IDLE_SHUTDOWN_SMOKE_EXIT_MS = 1200
-const IDLE_SHUTDOWN_ACTIVITY_EXIT_MS = 1500
-const IDLE_SHUTDOWN_SMOKE_MARGIN_MS = 250
+const IDLE_SHUTDOWN_SMOKE_EXIT_MS = 2500
+const IDLE_SHUTDOWN_ACTIVITY_EXIT_MS = 3000
+const IDLE_SHUTDOWN_SMOKE_MARGIN_MS = 500
 const IDLE_SHUTDOWN_DISABLED_OBSERVATION_MS =
 	Math.max(IDLE_SHUTDOWN_SMOKE_EXIT_MS, IDLE_SHUTDOWN_ACTIVITY_EXIT_MS) +
 	IDLE_SHUTDOWN_SMOKE_MARGIN_MS
@@ -832,10 +832,20 @@ async function runIdleShutdownSmoke(_sandboxRoot: string): Promise<void> {
 						isProcessAlive(runnerPid),
 						`${runner.name}: stdio runner not alive after connect`,
 					)
-					await new Promise((resolve) => setTimeout(resolve, idleExitMs / 2))
-					await callIdleActivityTool(runner.name, client)
 					await new Promise((resolve) =>
-						setTimeout(resolve, Math.floor(idleExitMs * 0.7)),
+						setTimeout(resolve, Math.floor(idleExitMs / 2)),
+					)
+					const activityStartedAt = Date.now()
+					await callIdleActivityTool(runner.name, client)
+					const elapsedSinceActivityStart = Date.now() - activityStartedAt
+					const beforeDeadlineWaitMs = Math.max(
+						0,
+						idleExitMs -
+							elapsedSinceActivityStart -
+							IDLE_SHUTDOWN_SMOKE_MARGIN_MS,
+					)
+					await new Promise((resolve) =>
+						setTimeout(resolve, beforeDeadlineWaitMs),
 					)
 					assert(
 						isProcessAlive(runnerPid),

--- a/scripts/smoke/run-smoke.ts
+++ b/scripts/smoke/run-smoke.ts
@@ -19,6 +19,7 @@ interface RunnerCase {
 		| 'biome-runner'
 		| 'claude-hooks'
 		| 'orphan-detection'
+		| 'idle-shutdown'
 	entrypoint: string
 	run(sandboxRoot: string): Promise<void>
 }
@@ -45,6 +46,12 @@ interface ProductionRunnerBinary {
 const REPO_ROOT = path.resolve(import.meta.dir, '..', '..')
 const TOOL_TIMEOUT_MS = 15_000
 const ORPHAN_RUNNER_STARTUP_SETTLE_MS = 500
+const IDLE_SHUTDOWN_SMOKE_EXIT_MS = 1200
+const IDLE_SHUTDOWN_ACTIVITY_EXIT_MS = 1500
+const IDLE_SHUTDOWN_SMOKE_MARGIN_MS = 250
+const IDLE_SHUTDOWN_DISABLED_OBSERVATION_MS =
+	Math.max(IDLE_SHUTDOWN_SMOKE_EXIT_MS, IDLE_SHUTDOWN_ACTIVITY_EXIT_MS) +
+	IDLE_SHUTDOWN_SMOKE_MARGIN_MS
 const PRODUCTION_RUNNER_BINARIES: ProductionRunnerBinary[] = [
 	{
 		name: 'tsc-runner',
@@ -92,19 +99,21 @@ async function createSandboxRoot(prefix: string): Promise<string> {
 async function withRunnerClient<T>(args: {
 	entrypoint: string
 	cwd: string
-	run: (client: Client) => Promise<T>
+	env?: Record<string, string>
+	run: (client: Client, transport: StdioClientTransport) => Promise<T>
 }): Promise<T> {
 	const client = new Client({ name: 'smoke-client', version: '0.0.1' })
 	const transport = new StdioClientTransport({
 		command: 'bun',
 		args: [args.entrypoint],
 		cwd: args.cwd,
+		env: args.env,
 		stderr: 'pipe',
 	})
 
 	try {
 		await client.connect(transport)
-		return await args.run(client)
+		return await args.run(client, transport)
 	} finally {
 		try {
 			await client.close()
@@ -382,26 +391,30 @@ async function runBiomeSmoke(sandboxRoot: string): Promise<void> {
 }
 
 /**
- * Spawn an intermediate process that itself spawns the runner binary with
- * fully detached stdio. Returns the intermediate's process handle and the
- * runner's PID (read from the intermediate's stdout).
+ * Spawn an intermediate process that itself spawns the runner binary and keeps
+ * ownership of the runner's stdio. Returns the intermediate handle and runner
+ * PID (read from the intermediate's stdout).
  *
- * Detached stdio is load-bearing: it ensures killing the intermediate does
- * not close the runner's stdin, so transport.onclose does not fire and the
- * watcher is the only mechanism that can trigger shutdown.
+ * For orphan detection, ignored stdio ensures killing the intermediate does not
+ * close stdin. For idle shutdown, piped stdio keeps parent-owned pipes open
+ * while the runner ages out with no useful activity.
  */
 async function spawnDetachedRunner(args: {
 	runnerEntry: string
 	parentCheckMs: string
+	idleExitMs?: string
+	stdioMode?: 'ignore' | 'pipe'
 }): Promise<{ intermediate: ReturnType<typeof Bun.spawn>; runnerPid: number }> {
 	const intermediateScript = `
 		const { spawn } = require('node:child_process');
+		const stdioMode = process.env.RUNNER_STDIO_MODE === 'pipe' ? 'pipe' : 'ignore';
 		const proc = spawn('bun', [process.env.RUNNER_ENTRY], {
 			detached: true,
-			stdio: ['ignore', 'ignore', 'ignore'],
+			stdio: [stdioMode, stdioMode, stdioMode],
 			env: {
 				...process.env,
 				MCP_PARENT_CHECK_MS: process.env.MCP_PARENT_CHECK_MS,
+				MCP_IDLE_EXIT_MS: process.env.MCP_IDLE_EXIT_MS,
 			},
 		});
 		proc.unref();
@@ -417,6 +430,8 @@ async function spawnDetachedRunner(args: {
 			...process.env,
 			RUNNER_ENTRY: args.runnerEntry,
 			MCP_PARENT_CHECK_MS: args.parentCheckMs,
+			MCP_IDLE_EXIT_MS: args.idleExitMs ?? '0',
+			RUNNER_STDIO_MODE: args.stdioMode ?? 'ignore',
 		},
 	})
 
@@ -518,7 +533,14 @@ async function waitForRunnerStartupSettle(): Promise<void> {
 	)
 }
 
+let productionRunnerBuildPromise: Promise<void> | undefined
+
 async function buildProductionRunnerBinaries(): Promise<void> {
+	productionRunnerBuildPromise ??= buildProductionRunnerBinariesOnce()
+	return productionRunnerBuildPromise
+}
+
+async function buildProductionRunnerBinariesOnce(): Promise<void> {
 	console.log('[smoke] building production runner binaries...')
 
 	for (const runner of PRODUCTION_RUNNER_BINARIES) {
@@ -536,6 +558,93 @@ async function buildProductionRunnerBinaries(): Promise<void> {
 	}
 }
 
+function createSmokeEnv(
+	overrides: Record<string, string>,
+): Record<string, string> {
+	const env: Record<string, string> = {}
+	for (const [key, value] of Object.entries(process.env)) {
+		if (typeof value === 'string') {
+			env[key] = value
+		}
+	}
+	return { ...env, ...overrides }
+}
+
+async function writeIdleActivityFixture(
+	runnerName: ProductionRunnerBinary['name'],
+	projectDir: string,
+): Promise<void> {
+	switch (runnerName) {
+		case 'tsc-runner':
+			await writeFile(
+				path.join(projectDir, 'tsconfig.json'),
+				JSON.stringify(
+					{
+						compilerOptions: {
+							target: 'ES2022',
+							module: 'NodeNext',
+							moduleResolution: 'NodeNext',
+							strict: true,
+							noEmit: true,
+							skipLibCheck: true,
+							types: [],
+						},
+					},
+					null,
+					2,
+				),
+			)
+			await writeFile(path.join(projectDir, 'index.ts'), 'const ok = 1;\n')
+			return
+		case 'bun-runner':
+			await writeFile(
+				path.join(projectDir, 'pass.test.ts'),
+				"import { expect, test } from 'bun:test';\ntest('pass', () => expect(1 + 1).toBe(2));\n",
+			)
+			return
+		case 'biome-runner':
+			await writeFile(path.join(projectDir, 'good.js'), 'const ok = 1\n')
+			return
+	}
+}
+
+async function callIdleActivityTool(
+	runnerName: ProductionRunnerBinary['name'],
+	client: Client,
+): Promise<void> {
+	switch (runnerName) {
+		case 'tsc-runner': {
+			const result = await callTool(client, 'tsc_check', {
+				path: '.',
+				response_format: 'json',
+			})
+			assert(result.isError === false, 'tsc_check failed during idle activity')
+			return
+		}
+		case 'bun-runner': {
+			const result = await callTool(client, 'bun_testCoverage', {
+				response_format: 'json',
+			})
+			assert(
+				result.isError === false,
+				'bun_testCoverage failed during idle activity',
+			)
+			return
+		}
+		case 'biome-runner': {
+			const result = await callTool(client, 'biome_formatCheck', {
+				path: '.',
+				response_format: 'json',
+			})
+			assert(
+				result.isError === false,
+				'biome_formatCheck failed during idle activity',
+			)
+			return
+		}
+	}
+}
+
 async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 	await buildProductionRunnerBinaries()
 
@@ -545,6 +654,7 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 			const { intermediate, runnerPid } = await spawnDetachedRunner({
 				runnerEntry: runner.entrypoint,
 				parentCheckMs: '200',
+				idleExitMs: '0',
 			})
 			try {
 				assert(
@@ -577,6 +687,7 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 			const { intermediate, runnerPid } = await spawnDetachedRunner({
 				runnerEntry: runner.entrypoint,
 				parentCheckMs: '0',
+				idleExitMs: '0',
 			})
 			try {
 				await waitForRunnerStartupSettle()
@@ -613,6 +724,7 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 			const { intermediate, runnerPid } = await spawnDetachedRunner({
 				runnerEntry: runner.entrypoint,
 				parentCheckMs: '10000',
+				idleExitMs: '0',
 			})
 			try {
 				await waitForRunnerStartupSettle()
@@ -621,6 +733,143 @@ async function runOrphanDetectionSmoke(_sandboxRoot: string): Promise<void> {
 				assert(
 					isProcessAlive(runnerPid),
 					`${runner.name}: with MCP_PARENT_CHECK_MS=10000, runner ${runnerPid} exited within 1s — interval is not honored`,
+				)
+			} finally {
+				if (isProcessAlive(runnerPid)) {
+					killRunnerProcessGroup(runnerPid)
+				}
+				try {
+					intermediate.kill('SIGKILL')
+				} catch {
+					// Ignore.
+				}
+				await intermediate.exited.catch(() => {})
+			}
+		}
+	}
+}
+
+async function runIdleShutdownSmoke(_sandboxRoot: string): Promise<void> {
+	await buildProductionRunnerBinaries()
+
+	for (const runner of PRODUCTION_RUNNER_BINARIES) {
+		// Happy path: parent and stdio pipes stay alive, but idle timeout exits.
+		{
+			const idleExitMs = IDLE_SHUTDOWN_SMOKE_EXIT_MS
+			const { intermediate, runnerPid } = await spawnDetachedRunner({
+				runnerEntry: runner.entrypoint,
+				parentCheckMs: '0',
+				idleExitMs: String(idleExitMs),
+				stdioMode: 'pipe',
+			})
+			try {
+				assert(
+					isProcessAlive(runnerPid),
+					`${runner.name}: runner not alive after spawn`,
+				)
+				await waitForRunnerStartupSettle()
+				assert(
+					isProcessAlive(runnerPid),
+					`${runner.name}: runner ${runnerPid} exited before the ${idleExitMs}ms idle deadline`,
+				)
+				const preDeadlineWindowMs = Math.max(
+					0,
+					idleExitMs -
+						ORPHAN_RUNNER_STARTUP_SETTLE_MS -
+						IDLE_SHUTDOWN_SMOKE_MARGIN_MS,
+				)
+				const exitedBeforeDeadline = await waitForExit(
+					runnerPid,
+					preDeadlineWindowMs,
+				)
+				assert(
+					!exitedBeforeDeadline,
+					`${runner.name}: runner ${runnerPid} exited before the ${idleExitMs}ms idle deadline`,
+				)
+				assert(
+					isProcessAlive(intermediate.pid as number),
+					`${runner.name}: intermediate process ${intermediate.pid} unexpectedly exited before idle assertion`,
+				)
+				const exited = await waitForExit(runnerPid, 5000)
+				assert(
+					exited,
+					`${runner.name}: runner ${runnerPid} did not exit within 5s while parent and stdio pipes stayed open (idle shutdown should have fired)`,
+				)
+			} finally {
+				if (isProcessAlive(runnerPid)) {
+					killRunnerProcessGroup(runnerPid)
+				}
+				try {
+					intermediate.kill('SIGKILL')
+				} catch {
+					// Ignore.
+				}
+				await intermediate.exited.catch(() => {})
+			}
+		}
+
+		// Real stdio request: tool activity resets the idle deadline in the built binary.
+		{
+			const idleExitMs = IDLE_SHUTDOWN_ACTIVITY_EXIT_MS
+			const projectDir = path.join(
+				_sandboxRoot,
+				`${runner.name}-idle-activity-project`,
+			)
+			await mkdir(projectDir, { recursive: true })
+			await writeIdleActivityFixture(runner.name, projectDir)
+
+			await withRunnerClient({
+				entrypoint: runner.entrypoint,
+				cwd: projectDir,
+				env: createSmokeEnv({
+					MCP_PARENT_CHECK_MS: '0',
+					MCP_IDLE_EXIT_MS: String(idleExitMs),
+				}),
+				run: async (client, transport) => {
+					const runnerPid = transport.pid
+					assert(runnerPid, `${runner.name}: missing stdio runner pid`)
+					assert(
+						isProcessAlive(runnerPid),
+						`${runner.name}: stdio runner not alive after connect`,
+					)
+					await new Promise((resolve) => setTimeout(resolve, idleExitMs / 2))
+					await callIdleActivityTool(runner.name, client)
+					await new Promise((resolve) =>
+						setTimeout(resolve, Math.floor(idleExitMs * 0.7)),
+					)
+					assert(
+						isProcessAlive(runnerPid),
+						`${runner.name}: runner exited before the request-rescheduled idle deadline`,
+					)
+					const exited = await waitForExit(runnerPid, 3000)
+					assert(
+						exited,
+						`${runner.name}: runner ${runnerPid} did not exit after rescheduled idle deadline`,
+					)
+				},
+			})
+		}
+
+		// Negative control: idle disabled — retained runner stays alive.
+		{
+			const { intermediate, runnerPid } = await spawnDetachedRunner({
+				runnerEntry: runner.entrypoint,
+				parentCheckMs: '0',
+				idleExitMs: '0',
+				stdioMode: 'pipe',
+			})
+			try {
+				await waitForRunnerStartupSettle()
+				await new Promise((resolve) =>
+					setTimeout(resolve, IDLE_SHUTDOWN_DISABLED_OBSERVATION_MS),
+				)
+				assert(
+					isProcessAlive(intermediate.pid as number),
+					`${runner.name}: intermediate process ${intermediate.pid} unexpectedly exited before idle negative control`,
+				)
+				assert(
+					isProcessAlive(runnerPid),
+					`${runner.name}: with MCP_IDLE_EXIT_MS=0, runner ${runnerPid} unexpectedly exited within ${IDLE_SHUTDOWN_DISABLED_OBSERVATION_MS}ms — retained-parent test is no longer trustworthy`,
 				)
 			} finally {
 				if (isProcessAlive(runnerPid)) {
@@ -743,6 +992,13 @@ async function run(): Promise<void> {
 			// dist/ binaries internally.
 			entrypoint: path.join(REPO_ROOT, 'packages/bun-runner/dist/index.js'),
 			run: runOrphanDetectionSmoke,
+		},
+		{
+			name: 'idle-shutdown',
+			// Entrypoint is informational here — the case loops over all three
+			// dist/ binaries internally.
+			entrypoint: path.join(REPO_ROOT, 'packages/bun-runner/dist/index.js'),
+			run: runIdleShutdownSmoke,
 		},
 	]
 


### PR DESCRIPTION
## Summary

Retained MCP runner processes now age out after 15 minutes without tracked activity, so abandoned app-hosted sessions do not keep `bun-runner`, `biome-runner`, or `tsc-runner` alive indefinitely. Clients that intentionally retain idle runners can keep the previous behavior by setting `MCP_IDLE_EXIT_MS=0`.

## Details

- Adds default-on idle shutdown wiring to all three stdio runner entrypoints.
- Tracks tool calls and `logging/setLevel` as activity; discovery/listing requests still do not keep an abandoned runner alive.
- Stops idle timers during shutdown and keeps shutdown idempotent alongside the existing parent-liveness watcher.
- Strengthens smoke coverage for retained parents, disabled idle shutdown, activity deadline resets, and cross-runner consistency.

## Release Note

This is a major changeset for all three runner packages because retained clients that relied on idle processes staying alive forever must opt out with `MCP_IDLE_EXIT_MS=0`.

## Validation

- `biome_lintCheck`
- `tsc_check`
- `bun_testFile packages/biome-runner/mcp/index.test.ts` → 46/46
- `bun_testFile packages/bun-runner/mcp/index.test.ts` → 55/55
- `bun_testFile packages/tsc-runner/mcp/index.test.ts` → 55/55
- `bun_runTests` → 193/193
- `bun run test:smoke`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retained runner processes now idle-shutdown by default after 15 minutes of inactivity; configurable via MCP_IDLE_EXIT_MS (set to 0 to disable).

* **Chores**
  * Major version bump for Biome Runner, Bun Runner, and TSC Runner.

* **Tests**
  * Expanded test and smoke coverage verifying idle-shutdown behavior and configurability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nathanvale/side-quest-runners/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->