### PR TITLE
fix(runners): accept linked worktree paths

### DIFF
--- a/.changeset/codex-worktree-runner-paths.md
+++ b/.changeset/codex-worktree-runner-paths.md
@@ -1,0 +1,8 @@
+---
+'@side-quest/bun-runner': patch
+'@side-quest/biome-runner': patch
+'@side-quest/tsc-runner': patch
+---
+
+Accept linked Git worktree paths for the configured repository and include the
+resolved execution cwd in JSON output for issue #71.

--- a/.changeset/idle-shutdown-opt-in.md
+++ b/.changeset/idle-shutdown-opt-in.md
@@ -1,0 +1,8 @@
+---
+'@side-quest/bun-runner': patch
+'@side-quest/biome-runner': patch
+'@side-quest/tsc-runner': patch
+---
+
+Make idle shutdown opt-in so deferred MCP tools stay available during long
+agent sessions unless hosts set `MCP_IDLE_EXIT_MS`.

--- a/docs/plans/2026-05-26-001-fix-codex-worktree-runner-paths-plan.md
+++ b/docs/plans/2026-05-26-001-fix-codex-worktree-runner-paths-plan.md
@@ -1,0 +1,442 @@
+---
+title: "fix: Accept Codex Git worktree paths in MCP runners"
+type: fix
+status: completed
+date: 2026-05-26
+origin: https://github.com/nathanvale/side-quest-runners/issues/71
+---
+
+# fix: Accept Codex Git worktree paths in MCP runners
+
+## Summary
+
+Teach the Bun, Biome, and TypeScript MCP runners to treat linked Git
+worktrees of the configured repository as valid execution roots. Path-bearing
+tools should infer the target checkout from the input path, suite-level tools
+should expose an explicit `cwd`, and JSON outputs should include the resolved
+execution cwd so agents can verify they used the active Codex worktree.
+
+---
+
+## Problem Frame
+
+Issue #71 reports that runner MCP tools reject absolute paths under
+Codex-created worktrees as `Path outside repository`, even when those paths are
+valid linked worktrees for the same repository. The current validators cache
+the server startup Git root and only accept real paths under that one checkout,
+which pushes agents back to raw repo CLIs and loses the runners' structured,
+token-efficient output.
+
+---
+
+## Requirements
+
+- R1. Accept absolute file or directory paths inside linked Git worktrees that
+  share the configured repository's Git common dir.
+- R2. Preserve traversal, null-byte, control-character, and symlink escape
+  protections for all path inputs.
+- R3. Resolve the execution cwd from the target worktree for tools that receive
+  a file or path input.
+- R4. Add an explicit `cwd` input for suite-level tools that otherwise have no
+  path from which to infer the active checkout.
+- R5. Include the resolved execution cwd in JSON structured output for all
+  runner tool calls.
+- R6. Keep backward compatibility for callers that omit `cwd` or pass paths in
+  the server startup checkout.
+- R7. Reject unrelated repositories and arbitrary filesystem paths with a
+  diagnostic that names the configured runner boundary.
+- R8. Cover the behavior across `bun-runner`, `biome-runner`, and `tsc-runner`
+  with unit and smoke coverage.
+
+---
+
+## Scope Boundaries
+
+- Do not turn the runners into arbitrary cross-repository command executors.
+  This plan accepts the startup checkout and linked worktrees for the same Git
+  common dir.
+- Do not introduce a shared package as part of this fix. The current repo still
+  keeps each runner self-contained; a later runner-core refactor may consolidate
+  the duplicated helper once behavior is proven.
+- Do not change MCP tool names or remove existing inputs.
+- Do not change parser semantics, diagnostic filtering, timeout policy, idle
+  shutdown behavior, or parent-liveness behavior.
+- Do not require Codex-specific environment variables or filesystem layout.
+
+### Deferred to Follow-Up Work
+
+- Move the new path-boundary helper into `runner-core` if the active runner CLI
+  primitive convergence plan lands first or resumes later.
+- Consider a broader "trusted extra roots" configuration only if a future issue
+  asks runners to operate across unrelated repositories.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/bun-runner/mcp/index.ts` caches `getGitRoot()` from process startup,
+  validates `bun_testFile.file`, validates path-like `bun_runTests.pattern`
+  values, and runs `bun test` from process cwd today.
+- `packages/biome-runner/mcp/index.ts` validates optional `path` inputs and
+  passes absolute target paths to Biome while spawning from process cwd.
+- `packages/tsc-runner/mcp/index.ts` validates optional `path`, then
+  `resolveWorkdir()` and `findNearestTsConfig()` stay bounded to the startup
+  Git root.
+- All three runners use realpath-based validation and `resolveNearestAncestor()`
+  to avoid missing symlink escapes for non-existent paths.
+- `scripts/smoke/run-smoke.ts` already builds production runner binaries and
+  has cross-runner smoke helpers for subprocess lifecycle tests.
+- Existing successful `tsc_check` output already includes `cwd`, which is the
+  right verification signal to extend across the runner tools.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/mcp-tool-discoverability-ab-benchmark.md`
+  treats MCP tool contracts as behavior that needs live validation, not just
+  compact schemas. This fix changes routing-relevant schema text and structured
+  output, so smoke coverage should prove agents can target the right runner.
+- `docs/plans/2026-05-18-001-refactor-runner-cli-primitive-convergence-plan.md`
+  identifies path validation as repeated runner primitive code, but that plan
+  is broader than issue #71. This bug should be fixed narrowly first unless
+  that refactor has already landed when implementation starts.
+
+### External References
+
+- Git worktrees expose a distinct worktree root while sharing a common Git dir
+  with the main checkout. `git rev-parse --show-toplevel` identifies the active
+  worktree root, and `git rev-parse --path-format=absolute --git-common-dir`
+  identifies the underlying repository store used to compare linked worktrees.
+
+---
+
+## Key Technical Decisions
+
+- **Use Git common dir as the trust boundary:** Compare the target path's
+  nearest Git common dir with the server startup common dir. This accepts Codex
+  worktrees for the same repo without opening the runner to unrelated repos.
+- **Return a path context, not just a string:** Replace plain `validatePath()`
+  internals with a helper that returns the canonical path, target worktree root,
+  startup root, and selected execution cwd. Keep exported `validatePath()`
+  returning a string where existing tests or callers depend on it.
+- **Preserve realpath-first safety:** Continue resolving the input path or
+  nearest existing ancestor through `realpath()` before deciding whether it is
+  inside an allowed worktree.
+- **Infer cwd from path-bearing inputs:** `bun_testFile`, Biome `path` tools,
+  and `tsc_check.path` should run from the worktree/config root associated with
+  the validated path, not from the runner server's process cwd.
+- **Add `cwd` only where inference is impossible:** Add `cwd` to
+  `bun_runTests` and `bun_testCoverage`; allow Biome and TSC callers to use
+  their existing `path` argument as the worktree selector.
+- **Make mixed path/cwd inputs strict:** When a tool receives both a target path
+  and `cwd`, both must resolve inside the same allowed worktree. Reject
+  mismatches rather than silently running one checkout against another.
+- **Expose cwd without wrapping every response in a new envelope:** Add a
+  `cwd` field to each structured output schema. For nested outputs such as
+  Biome fix results, add it at the top level beside the existing result fields.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should unrelated repos be accepted if callers pass an absolute path?** No.
+  The bug is about linked worktrees of the configured repo. Expanding to
+  unrelated repos would change the runner security model.
+- **Should this wait for runner-core extraction?** No. Issue #71 blocks the
+  current published runners. Keep the fix local and duplicated, then extract
+  later if the convergence plan proceeds.
+- **Should Biome and TSC receive new `cwd` inputs?** Not initially. Their
+  existing `path` inputs already identify the target checkout. Add `cwd` later
+  only if implementation finds a real suite-level gap.
+
+### Deferred to Implementation
+
+- **Exact helper names:** Let the implementing agent choose names that fit each
+  file, as long as the helper returns canonical path and target root context.
+- **Output text wording:** JSON shape must include `cwd`; markdown summaries can
+  add cwd where concise, but exact prose should follow existing formatter style.
+
+---
+
+## Implementation Units
+
+### U1. Add worktree-aware path context resolution
+
+**Goal:** Replace startup-root-only validation with a reusable local helper that
+accepts the startup checkout plus linked worktrees sharing the same Git common
+dir.
+
+**Requirements:** R1, R2, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/bun-runner/mcp/index.ts`
+- Modify: `packages/biome-runner/mcp/index.ts`
+- Modify: `packages/tsc-runner/mcp/index.ts`
+- Test: `packages/bun-runner/mcp/index.test.ts`
+- Test: `packages/biome-runner/mcp/index.test.ts`
+- Test: `packages/tsc-runner/mcp/index.test.ts`
+
+**Approach:**
+- Keep the current input checks for null bytes, control characters, blank
+  paths, and nearest-existing-ancestor realpath fallback.
+- Add startup repository context caching: startup worktree root plus absolute
+  startup Git common dir.
+- Resolve target repository context with `git -C <nearest-real-dir>
+  rev-parse --show-toplevel` and `git -C <nearest-real-dir> rev-parse
+  --path-format=absolute --git-common-dir`.
+- Accept the path when the real input is inside the startup root, or when the
+  target common dir matches the startup common dir and the real input is inside
+  the target worktree root.
+- Reject paths outside those roots with a clearer message such as
+  `Path outside configured runner repository or linked worktrees: <path>`.
+- Preserve `_resetGitRootCache()` behavior in tests, expanding it to reset the
+  new repository-context cache.
+
+**Execution note:** Add characterization coverage before changing each runner's
+validation helper so symlink and traversal protections stay locked.
+
+**Patterns to follow:**
+- Existing `validatePath()`, `resolveNearestAncestor()`, and
+  `_resetGitRootCache()` in each runner.
+- Existing symlink escape tests in `biome-runner` and `tsc-runner`; add the
+  missing Bun counterpart while touching the helper.
+
+**Test scenarios:**
+- Happy path: path in the startup checkout validates to its real path.
+- Happy path: path in a temporary linked worktree created with `git worktree
+  add --detach` validates and reports the linked worktree root.
+- Edge case: non-existent path under a linked worktree validates through the
+  nearest existing ancestor without losing the target worktree root.
+- Error path: path in an unrelated temporary Git repo is rejected with the
+  configured-runner-boundary diagnostic.
+- Error path: traversal such as `../../../etc/passwd` remains rejected.
+- Error path: symlink inside an allowed worktree pointing to `/tmp` remains
+  rejected.
+- Error path: null-byte and control-character inputs remain rejected.
+
+**Verification:**
+- Focused runner tests prove old protections and new linked-worktree acceptance
+  in all three packages.
+
+---
+
+### U2. Run path-bearing tools from the resolved target checkout
+
+**Goal:** Ensure file/path tools execute against the checkout identified by the
+validated input path, so configs, dependencies, and output cwd match the active
+worktree.
+
+**Requirements:** R1, R3, R5, R6, R8
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/bun-runner/mcp/index.ts`
+- Modify: `packages/biome-runner/mcp/index.ts`
+- Modify: `packages/tsc-runner/mcp/index.ts`
+- Test: `packages/bun-runner/mcp/index.test.ts`
+- Test: `packages/biome-runner/mcp/index.test.ts`
+- Test: `packages/tsc-runner/mcp/index.test.ts`
+
+**Approach:**
+- For `bun_testFile`, validate the file and run `bun test -- <validated-file>`
+  with spawn `cwd` set to the target worktree root.
+- For `bun_runTests` with a path-like `pattern`, validate the path and run from
+  that target worktree root. Preserve name-only pattern behavior by running
+  from the selected/default cwd.
+- For `biome_lintCheck`, `biome_lintFix`, and `biome_formatCheck`, validate
+  the target path and pass the target worktree root to `spawnWithTimeout()`.
+- For `tsc_check`, update `resolveWorkdir()` and `findNearestTsConfig()` so the
+  upward tsconfig search is bounded by the target worktree root instead of the
+  startup root.
+- Add `cwd` to structured outputs for Bun and Biome tools. Preserve existing
+  `tsc_check.cwd`, but ensure failure outputs use the resolved target cwd when
+  path resolution succeeded before a later failure.
+
+**Patterns to follow:**
+- Existing `spawnWithTimeout(..., { cwd })` signatures in Biome and TSC.
+- Existing `TscOutput.cwd` schema and markdown summary wording.
+- Existing MCP integration tests using `InMemoryTransport`.
+
+**Test scenarios:**
+- Happy path: `bun_testFile` called with an absolute linked-worktree test file
+  runs successfully and returns structured `cwd` for the linked worktree.
+- Happy path: Biome path tools called with an absolute linked-worktree path run
+  with structured `cwd` for the linked worktree.
+- Happy path: `tsc_check` called with an absolute linked-worktree path resolves
+  the nearest config inside that worktree and returns worktree `cwd`.
+- Edge case: name-only `bun_runTests.pattern` without `cwd` still uses the
+  startup checkout.
+- Error path: `tsc_check` for a linked-worktree directory without a config
+  returns `CONFIG_NOT_FOUND` bounded to that worktree, not the startup root.
+- Integration: JSON content and `structuredContent` both expose the same
+  resolved cwd where the tool supports JSON text output.
+
+**Verification:**
+- Focused integration tests show the command cwd and structured output cwd
+  match the linked worktree for each runner.
+
+---
+
+### U3. Add explicit cwd inputs for Bun suite-level tools
+
+**Goal:** Let agents pin the active worktree for Bun operations that do not
+otherwise receive a path.
+
+**Requirements:** R4, R5, R6, R8
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/bun-runner/mcp/index.ts`
+- Modify: `packages/bun-runner/mcp/index.test.ts`
+- Modify: `packages/bun-runner/README.md`
+
+**Approach:**
+- Add optional `cwd` to `bun_runTests` and `bun_testCoverage` input schemas.
+- Validate `cwd` with the same worktree-aware helper and run Bun from the
+  resolved worktree root.
+- When both `pattern` and `cwd` are supplied to `bun_runTests`, validate any
+  path-like pattern and require it to belong to the same resolved worktree as
+  `cwd`.
+- Keep `cwd` optional and default to current startup-root behavior when omitted.
+- Include the resolved cwd in structured output for both tools.
+
+**Patterns to follow:**
+- Existing optional `path` schema descriptions in Biome and TSC.
+- Existing tool-description style: concise action, boundary, and sibling-tool
+  guidance.
+
+**Test scenarios:**
+- Happy path: `bun_runTests` with `cwd` set to a linked worktree and a test-name
+  pattern runs from that worktree and reports that cwd.
+- Happy path: `bun_testCoverage` with `cwd` set to a linked worktree runs from
+  that worktree and reports that cwd.
+- Edge case: omitted `cwd` preserves existing startup-root execution.
+- Error path: `cwd` in an unrelated Git repo is rejected.
+- Error path: `cwd` in one worktree plus path-like `pattern` in another
+  worktree is rejected as a mixed-checkout request.
+- Contract: tool list schemas expose `cwd` with a concise description.
+
+**Verification:**
+- Bun runner integration tests cover `cwd` defaulting, linked worktree
+  execution, and mixed-checkout rejection.
+
+---
+
+### U4. Update docs, changesets, and production smoke coverage
+
+**Goal:** Prove the published runner binaries accept Codex-style linked
+worktree paths and document the new cwd contract for callers.
+
+**Requirements:** R1, R4, R5, R8
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `scripts/smoke/run-smoke.ts`
+- Modify: `packages/bun-runner/README.md`
+- Modify: `packages/biome-runner/README.md`
+- Modify: `packages/tsc-runner/README.md`
+- Create: `.changeset/<generated-name>.md`
+
+**Approach:**
+- Add a smoke case that creates a temporary linked worktree from the current
+  repository, writes small runner-specific fixtures inside it, then invokes the
+  built production runners from their package dirs using absolute worktree
+  paths or Bun `cwd`.
+- Assert each structured JSON result includes a `cwd` under the linked
+  worktree, not the startup checkout.
+- Keep the smoke fixture self-cleaning with `git worktree remove --force` in a
+  `finally` block.
+- Update READMEs to describe linked worktree support, the Bun `cwd` option, and
+  the `cwd` field in JSON output.
+- Add a patch changeset for `@side-quest/bun-runner`,
+  `@side-quest/biome-runner`, and `@side-quest/tsc-runner`.
+
+**Patterns to follow:**
+- Existing production-binary smoke setup in `scripts/smoke/run-smoke.ts`.
+- Existing package README tool sections.
+- Existing `.changeset/idle-shutdown-retained-runners.md` format.
+
+**Test scenarios:**
+- Smoke: built `tsc-runner` accepts a linked-worktree project path and reports
+  worktree cwd.
+- Smoke: built `bun-runner` accepts `cwd` for a linked-worktree test fixture and
+  reports worktree cwd.
+- Smoke: built `biome-runner` accepts a linked-worktree path and reports
+  worktree cwd.
+- Cleanup: smoke removes the temporary worktree even when one runner assertion
+  fails.
+
+**Verification:**
+- `bun_runTests` passes for the affected package tests.
+- `biome_lintCheck` passes after edits.
+- `tsc_check` passes.
+- `bun run build` and `bun test:smoke` pass before handoff or PR.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** All public MCP runner tools keep their names, but
+  schema metadata and structured output grow a `cwd` signal. Bun suite-level
+  tools also gain a new optional input.
+- **Error propagation:** Path-boundary failures should still return tool errors.
+  The message should distinguish "outside configured runner repo/worktrees"
+  from generic spawn failures where practical.
+- **State lifecycle risks:** Temporary Git worktrees in tests and smoke must be
+  removed reliably to avoid dirty `.git/worktrees` metadata.
+- **API surface parity:** `cwd` output should be present across Bun, Biome, and
+  TSC JSON outputs so agents can verify execution roots consistently.
+- **Integration coverage:** Unit tests prove helper boundaries; smoke tests
+  prove built binaries work from package dirs against a linked worktree.
+- **Unchanged invariants:** Existing traversal and symlink escape protections
+  remain mandatory. Callers without `cwd` or linked-worktree paths should see
+  unchanged behavior except for the additive `cwd` field.
+
+---
+
+## Risks & Dependencies
+
+- **Risk: security boundary accidentally expands to arbitrary repos.**
+  Mitigation: compare Git common dirs and add unrelated-repo rejection tests.
+- **Risk: symlink escape regression while adding worktree acceptance.**
+  Mitigation: keep realpath-first validation and add Bun symlink coverage to
+  match Biome and TSC.
+- **Risk: Git worktree smoke tests leave behind metadata after failure.**
+  Mitigation: wrap creation/removal in `try/finally`; use detached worktrees
+  with unique temporary directories.
+- **Risk: output schema additions surprise strict consumers.**
+  Mitigation: make fields additive, update output schemas and READMEs, and ship
+  as patch changesets for all three packages.
+- **Risk: Biome config discovery differs when passing absolute paths.**
+  Mitigation: run Biome subprocesses with cwd set to the target worktree root
+  while keeping validated absolute target paths.
+
+---
+
+## Documentation / Operational Notes
+
+- Add README examples showing Codex worktree usage:
+  `bun_runTests({ cwd: "/path/to/worktree", response_format: "json" })` and
+  path-bearing tools with absolute worktree paths.
+- Mention that `cwd` in JSON output is the verification field agents should
+  inspect before trusting diagnostics.
+- Include issue #71 in the changeset summary.
+
+---
+
+## Sources & References
+
+- Related issue: [#71](https://github.com/nathanvale/side-quest-runners/issues/71)
+- Related plan: `docs/plans/2026-05-18-001-refactor-runner-cli-primitive-convergence-plan.md`
+- Related code: `packages/bun-runner/mcp/index.ts`
+- Related code: `packages/biome-runner/mcp/index.ts`
+- Related code: `packages/tsc-runner/mcp/index.ts`
+- Related smoke harness: `scripts/smoke/run-smoke.ts`

--- a/packages/biome-runner/README.md
+++ b/packages/biome-runner/README.md
@@ -31,6 +31,21 @@ Or in `.mcp.json`:
 
 All tools accept a `response_format` parameter (`"markdown"` or `"json"`). Use `"json"` for token-efficient structured output in agent pipelines.
 
+JSON responses include `cwd`, the worktree root used to run Biome. Inspect it
+when passing absolute paths from Codex or other Git worktrees.
+
+## Git Worktrees
+
+The runner accepts paths in the startup checkout and linked Git worktrees that
+share the same Git common dir. Unrelated repositories remain blocked.
+
+```json
+{
+  "path": "/path/to/codex-worktree/src/index.ts",
+  "response_format": "json"
+}
+```
+
 ## License
 
 MIT

--- a/packages/biome-runner/mcp/index.test.ts
+++ b/packages/biome-runner/mcp/index.test.ts
@@ -630,16 +630,17 @@ describe('parseParentCheckMs', () => {
 })
 
 describe('parseIdleExitMs', () => {
-	test('returns default when env is undefined', () => {
+	test('returns default disabled value when env is undefined', () => {
+		expect(DEFAULT_IDLE_EXIT_MS).toBe(0)
 		expect(parseIdleExitMs(undefined)).toBe(DEFAULT_IDLE_EXIT_MS)
 	})
 
-	test('returns default for empty / whitespace string', () => {
+	test('returns default disabled value for empty / whitespace string', () => {
 		expect(parseIdleExitMs('')).toBe(DEFAULT_IDLE_EXIT_MS)
 		expect(parseIdleExitMs('   ')).toBe(DEFAULT_IDLE_EXIT_MS)
 	})
 
-	test('returns default for non-numeric / NaN values', () => {
+	test('returns default disabled value for non-numeric / NaN values', () => {
 		expect(parseIdleExitMs('abc')).toBe(DEFAULT_IDLE_EXIT_MS)
 		expect(parseIdleExitMs('NaN')).toBe(DEFAULT_IDLE_EXIT_MS)
 	})
@@ -662,23 +663,19 @@ describe('parseIdleExitMs', () => {
 })
 
 describe('createIdleShutdownWatcherFromEnv', () => {
-	test('uses the default idle timeout when env is omitted', () => {
+	test('leaves idle shutdown disabled when env is omitted', () => {
 		const calls: number[] = []
-		const fakeWatcher = {
-			recordRequestStart: () => () => {},
-			stop: () => {},
-		}
 		const result = createIdleShutdownWatcherFromEnv({
 			env: {},
 			onIdle: () => {},
 			createWatcher: (opts) => {
 				calls.push(opts.idleMs)
-				return fakeWatcher
+				return undefined
 			},
 		})
 
 		expect(result.idleMs).toBe(DEFAULT_IDLE_EXIT_MS)
-		expect(result.watcher).toBe(fakeWatcher)
+		expect(result.watcher).toBeUndefined()
 		expect(calls).toEqual([DEFAULT_IDLE_EXIT_MS])
 	})
 

--- a/packages/biome-runner/mcp/index.test.ts
+++ b/packages/biome-runner/mcp/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, spyOn, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
-import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
@@ -20,11 +21,44 @@ import {
 	parseBiomeOutput,
 	parseIdleExitMs,
 	parseParentCheckMs,
+	resolvePathContext,
 	SERVER_VERSION,
 	spawnWithTimeout,
 	validatePath,
 	validatePathOrDefault,
 } from './index'
+
+async function runGit(args: string[], cwd = process.cwd()): Promise<void> {
+	const proc = Bun.spawn(['git', ...args], {
+		cwd,
+		stdout: 'pipe',
+		stderr: 'pipe',
+	})
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	])
+	if (exitCode !== 0) {
+		throw new Error(`git ${args.join(' ')} failed (${exitCode}): ${stdout}${stderr}`)
+	}
+}
+
+async function createLinkedWorktree(prefix: string): Promise<{
+	worktree: string
+	cleanup: () => Promise<void>
+}> {
+	const parent = await mkdtemp(path.join(tmpdir(), `${prefix}-`))
+	const worktree = path.join(parent, 'checkout')
+	await runGit(['worktree', 'add', '--detach', worktree, 'HEAD'])
+	return {
+		worktree,
+		cleanup: async () => {
+			await runGit(['worktree', 'remove', '--force', worktree]).catch(() => undefined)
+			await rm(parent, { recursive: true, force: true })
+		},
+	}
+}
 
 describe('parseBiomeOutput', () => {
 	test('parses empty diagnostics', () => {
@@ -167,7 +201,9 @@ describe('path validation', () => {
 	})
 
 	test('rejects traversal paths outside repository', async () => {
-		await expect(validatePath('../../../etc/passwd')).rejects.toThrow('Path outside repository')
+		await expect(validatePath('../../../etc/passwd')).rejects.toThrow(
+			'Path outside configured runner repository or linked worktrees',
+		)
 	})
 
 	test('rejects symlink escape outside repository', async () => {
@@ -175,9 +211,55 @@ describe('path validation', () => {
 		await rm(linkPath, { force: true })
 		await symlink('/tmp', linkPath)
 		try {
-			await expect(validatePath(linkPath)).rejects.toThrow('Path outside repository')
+			await expect(validatePath(linkPath)).rejects.toThrow(
+				'Path outside configured runner repository or linked worktrees',
+			)
 		} finally {
 			await rm(linkPath, { force: true })
+		}
+	})
+
+	test('accepts paths in linked worktrees for the same repository', async () => {
+		_resetGitRootCache()
+		const { worktree, cleanup } = await createLinkedWorktree('biome-runner-linked-worktree')
+		try {
+			const packagePath = path.join(worktree, 'package.json')
+			const context = await resolvePathContext(packagePath)
+
+			expect(context.realPath).toBe(await realpath(packagePath))
+			expect(context.worktreeRoot).toBe(await realpath(worktree))
+		} finally {
+			await cleanup()
+		}
+	})
+
+	test('accepts missing paths under linked worktrees via nearest ancestor', async () => {
+		_resetGitRootCache()
+		const { worktree, cleanup } = await createLinkedWorktree('biome-runner-missing-linked-worktree')
+		try {
+			const missingPath = path.join(worktree, 'reports', 'future.ts')
+			const context = await resolvePathContext(missingPath)
+
+			expect(context.realPath).toBe(path.join(await realpath(worktree), 'reports', 'future.ts'))
+			expect(context.worktreeRoot).toBe(await realpath(worktree))
+		} finally {
+			await cleanup()
+		}
+	})
+
+	test('rejects paths in unrelated git repositories', async () => {
+		_resetGitRootCache()
+		const unrelatedRepo = await mkdtemp(path.join(tmpdir(), 'biome-runner-unrelated-repo-'))
+		try {
+			await runGit(['init'], unrelatedRepo)
+			const filePath = path.join(unrelatedRepo, 'index.ts')
+			await writeFile(filePath, 'export const value = 1;\n')
+
+			await expect(validatePath(filePath)).rejects.toThrow(
+				'Path outside configured runner repository or linked worktrees',
+			)
+		} finally {
+			await rm(unrelatedRepo, { recursive: true, force: true })
 		}
 	})
 })
@@ -321,16 +403,58 @@ describe('biome tools integration', () => {
 			expect(result.structuredContent).toBeDefined()
 
 			const output = result.structuredContent as {
+				cwd: string
 				errorCount: number
 				warningCount: number
 				diagnostics: Array<{ file: string; message: string }>
 			}
 
+			expect(typeof output.cwd).toBe('string')
 			expect(typeof output.errorCount).toBe('number')
 			expect(typeof output.warningCount).toBe('number')
 			expect(Array.isArray(output.diagnostics)).toBe(true)
+			expect(JSON.parse(result.content[0]?.text as string).cwd).toBe(output.cwd)
 		} finally {
 			await Promise.all([client.close(), server.close()])
+		}
+	})
+
+	test('lintCheck runs linked-worktree paths from that worktree cwd', async () => {
+		_resetGitRootCache()
+		const { worktree, cleanup } = await createLinkedWorktree('biome-runner-tool-linked-worktree')
+		const fixtureDir = path.join(worktree, 'reports', 'biome-linked-fixture')
+		await mkdir(fixtureDir, { recursive: true })
+		const fixtureFile = path.join(fixtureDir, 'good.js')
+		await writeFile(fixtureFile, 'export const ok = 1\n')
+
+		const server = await createBiomeServer()
+		const client = new Client({ name: 'biome-client', version: '0.0.1' })
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+		try {
+			const result = await client.callTool({
+				name: 'biome_lintCheck',
+				arguments: {
+					path: fixtureFile,
+					response_format: 'json',
+				},
+			})
+
+			expect(result.isError).toBe(false)
+			const output = result.structuredContent as {
+				cwd: string
+				errorCount: number
+				warningCount: number
+			}
+			expect(output.cwd).toBe(await realpath(worktree))
+			expect(output.errorCount).toBe(0)
+			expect(output.warningCount).toBe(0)
+			expect(JSON.parse(result.content[0]?.text as string).cwd).toBe(output.cwd)
+		} finally {
+			await Promise.all([client.close(), server.close()])
+			await cleanup()
 		}
 	})
 
@@ -413,10 +537,12 @@ describe('biome tools integration', () => {
 			expect(result.structuredContent).toBeDefined()
 
 			const output = result.structuredContent as {
+				cwd: string
 				formatted: boolean
 				unformattedFiles: string[]
 			}
 
+			expect(typeof output.cwd).toBe('string')
 			expect(typeof output.formatted).toBe('boolean')
 			expect(Array.isArray(output.unformattedFiles)).toBe(true)
 		} finally {
@@ -450,10 +576,12 @@ describe('biome tools integration', () => {
 			expect(result.structuredContent).toBeDefined()
 
 			const output = result.structuredContent as {
+				cwd: string
 				fixed: number
 				remaining: { errorCount: number; warningCount: number; diagnostics: unknown[] }
 			}
 
+			expect(typeof output.cwd).toBe('string')
 			expect(typeof output.fixed).toBe('number')
 			expect(typeof output.remaining.errorCount).toBe('number')
 			expect(typeof output.remaining.warningCount).toBe('number')

--- a/packages/biome-runner/mcp/index.ts
+++ b/packages/biome-runner/mcp/index.ts
@@ -1395,8 +1395,11 @@ export const MIN_PARENT_CHECK_MS = 50
 
 /**
  * Default idle shutdown interval in milliseconds.
+ *
+ * Zero keeps runners available unless the host opts into idle cleanup with
+ * MCP_IDLE_EXIT_MS.
  */
-export const DEFAULT_IDLE_EXIT_MS = 900_000
+export const DEFAULT_IDLE_EXIT_MS = 0
 
 /**
  * Lower bound for the idle interval to prevent event-loop saturation.
@@ -1566,8 +1569,8 @@ interface IdleExitEnv {
 /**
  * Create idle shutdown wiring from process-style environment values.
  *
- * Why: startBiomeServer should exercise the same default-on / disabled parsing
- * as unit tests without making runtime smoke wait for the 15-minute default.
+ * Why: startBiomeServer should exercise the same opt-in / disabled parsing as
+ * unit tests.
  */
 export function createIdleShutdownWatcherFromEnv(opts: {
 	env: IdleExitEnv

--- a/packages/biome-runner/mcp/index.ts
+++ b/packages/biome-runner/mcp/index.ts
@@ -153,7 +153,7 @@ const lintDiagnosticSchema: z.ZodObject<{
 	suggestion: z.string().optional().nullable(),
 })
 
-const lintSummarySchema: z.ZodObject<{
+const lintSummaryCoreSchema: z.ZodObject<{
 	errorCount: z.ZodNumber
 	warningCount: z.ZodNumber
 	diagnostics: z.ZodArray<typeof lintDiagnosticSchema>
@@ -163,18 +163,26 @@ const lintSummarySchema: z.ZodObject<{
 	diagnostics: z.array(lintDiagnosticSchema),
 })
 
+const lintSummarySchema = lintSummaryCoreSchema.extend({
+	cwd: z.string(),
+})
+
 const lintFixSchema: z.ZodObject<{
+	cwd: z.ZodString
 	fixed: z.ZodNumber
-	remaining: typeof lintSummarySchema
+	remaining: typeof lintSummaryCoreSchema
 }> = z.object({
+	cwd: z.string(),
 	fixed: z.number(),
-	remaining: lintSummarySchema,
+	remaining: lintSummaryCoreSchema,
 })
 
 const formatCheckSchema: z.ZodObject<{
+	cwd: z.ZodString
 	formatted: z.ZodBoolean
 	unformattedFiles: z.ZodArray<z.ZodString>
 }> = z.object({
+	cwd: z.string(),
 	formatted: z.boolean(),
 	unformattedFiles: z.array(z.string()),
 })
@@ -191,6 +199,19 @@ const PACKAGE_VERSION: string = JSON.parse(
 export const SERVER_VERSION: string = PACKAGE_VERSION
 
 let _gitRootPromise: Promise<string> | null = null
+let _repositoryContextPromise: Promise<RepositoryContext> | null = null
+
+interface RepositoryContext {
+	worktreeRoot: string
+	gitCommonDir: string
+}
+
+interface PathContext {
+	realPath: string
+	worktreeRoot: string
+	startupRoot: string
+	gitCommonDir: string
+}
 
 /**
  * Get the git root once per process using promise coalescing.
@@ -202,12 +223,36 @@ export function getGitRoot(): Promise<string> {
 	if (_gitRootPromise !== null) {
 		return _gitRootPromise
 	}
-	_gitRootPromise = resolveGitRoot()
+	_gitRootPromise = getStartupRepositoryContext().then(
+		(context) => context.worktreeRoot,
+	)
 	return _gitRootPromise
 }
 
-async function resolveGitRoot(): Promise<string> {
-	const proc = Bun.spawn(['git', 'rev-parse', '--show-toplevel'], {
+async function getStartupRepositoryContext(): Promise<RepositoryContext> {
+	if (_repositoryContextPromise !== null) {
+		return _repositoryContextPromise
+	}
+	_repositoryContextPromise = resolveRepositoryContext(process.cwd())
+	return _repositoryContextPromise
+}
+
+async function resolveRepositoryContext(
+	cwd: string,
+): Promise<RepositoryContext> {
+	const [worktreeRoot, gitCommonDir] = await Promise.all([
+		resolveGitPath(cwd, ['--show-toplevel']),
+		resolveGitPath(cwd, ['--path-format=absolute', '--git-common-dir']),
+	])
+
+	return {
+		worktreeRoot: await realpath(worktreeRoot),
+		gitCommonDir: await realpath(gitCommonDir),
+	}
+}
+
+async function resolveGitPath(cwd: string, args: string[]): Promise<string> {
+	const proc = Bun.spawn(['git', '-C', cwd, 'rev-parse', ...args], {
 		stdout: 'pipe',
 		stderr: 'pipe',
 	})
@@ -221,7 +266,7 @@ async function resolveGitRoot(): Promise<string> {
 		throw new Error('Not inside a git repository')
 	}
 
-	return realpath(stdout.trim())
+	return stdout.trim()
 }
 
 /**
@@ -229,6 +274,7 @@ async function resolveGitRoot(): Promise<string> {
  */
 export function _resetGitRootCache(): void {
 	_gitRootPromise = null
+	_repositoryContextPromise = null
 }
 
 /**
@@ -240,11 +286,17 @@ export function _resetGitRootCache(): void {
 export async function validatePathOrDefault(
 	inputPath?: string,
 ): Promise<string> {
+	return (await resolvePathContextOrDefault(inputPath)).realPath
+}
+
+async function resolvePathContextOrDefault(
+	inputPath?: string,
+): Promise<PathContext> {
 	const candidate =
 		inputPath === undefined || inputPath.trim() === ''
 			? process.cwd()
 			: inputPath
-	return validatePath(candidate)
+	return resolvePathContext(candidate)
 }
 
 /**
@@ -254,6 +306,13 @@ export async function validatePathOrDefault(
  * the current repository boundary.
  */
 export async function validatePath(inputPath: string): Promise<string> {
+	return (await resolvePathContext(inputPath)).realPath
+}
+
+export async function resolvePathContext(
+	inputPath: string,
+	options?: { baseDir?: string },
+): Promise<PathContext> {
 	if (inputPath.includes('\x00')) {
 		throw new Error('Path contains null byte')
 	}
@@ -266,26 +325,63 @@ export async function validatePath(inputPath: string): Promise<string> {
 		throw new Error('Path cannot be empty')
 	}
 
-	const resolvedPath = path.resolve(inputPath)
+	const resolvedPath = path.resolve(
+		options?.baseDir ?? process.cwd(),
+		inputPath,
+	)
 	let realInputPath: string
+	let nearestExistingDir: string
 
 	try {
 		realInputPath = await realpath(resolvedPath)
+		nearestExistingDir = (await stat(realInputPath)).isDirectory()
+			? realInputPath
+			: path.dirname(realInputPath)
 	} catch (error) {
 		const err = error as NodeJS.ErrnoException
 		if (err.code === 'ENOENT') {
-			realInputPath = await resolveNearestAncestor(resolvedPath)
+			const resolved = await resolveNearestAncestor(resolvedPath)
+			realInputPath = resolved.realPath
+			nearestExistingDir = resolved.nearestExistingDir
 		} else {
 			throw new Error(`Cannot resolve path: ${err.message}`)
 		}
 	}
 
-	const gitRoot = await getGitRoot()
-	if (realInputPath !== gitRoot && !realInputPath.startsWith(`${gitRoot}/`)) {
-		throw new Error(`Path outside repository: ${inputPath}`)
+	const startupContext = await getStartupRepositoryContext()
+	if (isPathInsideOrEqual(realInputPath, startupContext.worktreeRoot)) {
+		return {
+			realPath: realInputPath,
+			worktreeRoot: startupContext.worktreeRoot,
+			startupRoot: startupContext.worktreeRoot,
+			gitCommonDir: startupContext.gitCommonDir,
+		}
 	}
 
-	return realInputPath
+	let targetContext: RepositoryContext
+	try {
+		targetContext = await resolveRepositoryContext(nearestExistingDir)
+	} catch {
+		throw new Error(
+			`Path outside configured runner repository or linked worktrees: ${inputPath}`,
+		)
+	}
+
+	if (
+		targetContext.gitCommonDir === startupContext.gitCommonDir &&
+		isPathInsideOrEqual(realInputPath, targetContext.worktreeRoot)
+	) {
+		return {
+			realPath: realInputPath,
+			worktreeRoot: targetContext.worktreeRoot,
+			startupRoot: startupContext.worktreeRoot,
+			gitCommonDir: targetContext.gitCommonDir,
+		}
+	}
+
+	throw new Error(
+		`Path outside configured runner repository or linked worktrees: ${inputPath}`,
+	)
 }
 
 function hasControlCharacters(value: string): boolean {
@@ -305,7 +401,10 @@ function hasControlCharacters(value: string): boolean {
  * Why: a naive fallback to path.resolve on ENOENT misses intermediate symlinks
  * that could escape the repository boundary.
  */
-async function resolveNearestAncestor(resolvedPath: string): Promise<string> {
+async function resolveNearestAncestor(resolvedPath: string): Promise<{
+	realPath: string
+	nearestExistingDir: string
+}> {
 	let dir = path.dirname(resolvedPath)
 	const suffix = path.basename(resolvedPath)
 	const segments: string[] = [suffix]
@@ -313,14 +412,30 @@ async function resolveNearestAncestor(resolvedPath: string): Promise<string> {
 	while (dir !== path.dirname(dir)) {
 		try {
 			const realDir = await realpath(dir)
-			return path.join(realDir, ...segments)
+			return {
+				realPath: path.join(realDir, ...segments),
+				nearestExistingDir: realDir,
+			}
 		} catch {
 			segments.unshift(path.basename(dir))
 			dir = path.dirname(dir)
 		}
 	}
 
-	return resolvedPath
+	return {
+		realPath: resolvedPath,
+		nearestExistingDir: path.dirname(resolvedPath),
+	}
+}
+
+function isPathInsideOrEqual(candidatePath: string, rootPath: string): boolean {
+	const relative = path.relative(rootPath, candidatePath)
+	return (
+		relative === '' ||
+		(relative.length > 0 &&
+			!relative.startsWith('..') &&
+			!path.isAbsolute(relative))
+	)
 }
 
 /**
@@ -729,13 +844,17 @@ async function ensurePathExists(validatedPath: string): Promise<void> {
 	}
 }
 
-async function runBiomeCheck(inputPath = '.'): Promise<LintSummary> {
+async function runBiomeCheck(
+	inputPath = '.',
+	cwd = process.cwd(),
+): Promise<z.infer<typeof lintSummaryCoreSchema>> {
 	const invocation = createBiomeInvocation({
 		subcommand: 'check',
 		path: inputPath,
 	})
 	const { stdout, stderr, timedOut, stdoutTruncated, stderrTruncated } =
 		await spawnWithTimeout(invocation.cmd, {
+			cwd,
 			env: invocation.env,
 			timeoutMs: BIOME_TIMEOUT_MS,
 		})
@@ -758,6 +877,7 @@ async function runBiomeCheck(inputPath = '.'): Promise<LintSummary> {
 
 async function runBiomeFix(
 	inputPath = '.',
+	cwd = process.cwd(),
 ): Promise<z.infer<typeof lintFixSchema>> {
 	// biome check --write applies both formatting and lint fixes in one pass.
 	// We keep one post-fix check subprocess to return remaining diagnostics.
@@ -767,6 +887,7 @@ async function runBiomeFix(
 		write: true,
 	})
 	const fix = await spawnWithTimeout(fixInvocation.cmd, {
+		cwd,
 		env: fixInvocation.env,
 		timeoutMs: BIOME_TIMEOUT_MS,
 	})
@@ -784,7 +905,7 @@ async function runBiomeFix(
 		)
 	}
 
-	const remaining = await runBiomeCheck(inputPath)
+	const remaining = await runBiomeCheck(inputPath, cwd)
 
 	const report = parseBiomeOutput(fix.stdout || fix.stderr)
 	const fixed = Math.max(
@@ -795,6 +916,7 @@ async function runBiomeFix(
 	)
 
 	return {
+		cwd,
 		fixed,
 		remaining,
 	}
@@ -802,6 +924,7 @@ async function runBiomeFix(
 
 async function runBiomeFormatCheck(
 	inputPath = '.',
+	cwd = process.cwd(),
 ): Promise<z.infer<typeof formatCheckSchema>> {
 	const invocation = createBiomeInvocation({
 		subcommand: 'format',
@@ -809,6 +932,7 @@ async function runBiomeFormatCheck(
 	})
 	const { stdout, exitCode, timedOut, stdoutTruncated, stderrTruncated } =
 		await spawnWithTimeout(invocation.cmd, {
+			cwd,
 			env: invocation.env,
 			timeoutMs: BIOME_TIMEOUT_MS,
 		})
@@ -827,7 +951,7 @@ async function runBiomeFormatCheck(
 	}
 
 	if (exitCode === 0) {
-		return { formatted: true, unformattedFiles: [] }
+		return { cwd, formatted: true, unformattedFiles: [] }
 	}
 
 	const unformattedFiles: string[] = []
@@ -845,11 +969,11 @@ async function runBiomeFormatCheck(
 		// Parse failures still indicate files are not formatted.
 	}
 
-	return { formatted: false, unformattedFiles }
+	return { cwd, formatted: false, unformattedFiles }
 }
 
 function formatLintSummary(
-	summary: LintSummary,
+	summary: LintSummary & { cwd?: string },
 	format: 'markdown' | 'json',
 ): string {
 	if (format === 'json') {
@@ -933,13 +1057,14 @@ function getCommonDiagnosticFile(diagnostics: LintDiagnostic[]): string | null {
 }
 
 export function compactLintSummaryForJsonText(
-	summary: LintSummary,
+	summary: LintSummary & { cwd?: string },
 ): Record<string, unknown> {
 	const commonFile = getCommonDiagnosticFile(summary.diagnostics)
 	if (!commonFile) {
 		return stripNullishDeep(summary) as unknown as Record<string, unknown>
 	}
 	return stripNullishDeep({
+		cwd: summary.cwd,
 		errorCount: summary.errorCount,
 		warningCount: summary.warningCount,
 		commonFile,
@@ -957,6 +1082,7 @@ export function compactLintFixResultForJsonText(
 	result: z.infer<typeof lintFixSchema>,
 ): Record<string, unknown> {
 	return stripNullishDeep({
+		cwd: result.cwd,
 		fixed: result.fixed,
 		remaining: compactLintSummaryForJsonText(result.remaining),
 	}) as Record<string, unknown>
@@ -1066,18 +1192,26 @@ export async function createBiomeServer(
 					},
 					async () => {
 						try {
-							const validatedPath = await validatePathOrDefault(args.path)
-							await ensurePathExists(validatedPath)
-							const summary = await runBiomeCheck(validatedPath)
+							const pathContext = await resolvePathContextOrDefault(args.path)
+							await ensurePathExists(pathContext.realPath)
+							const summary = await runBiomeCheck(
+								pathContext.realPath,
+								pathContext.worktreeRoot,
+							)
+							const output = {
+								cwd: pathContext.worktreeRoot,
+								...summary,
+							}
 							const format = args.response_format
 							lintCheckLogger.info('biome_lintCheck completed', {
-								path: validatedPath,
+								path: pathContext.realPath,
+								cwd: output.cwd,
 								errorCount: summary.errorCount,
 								warningCount: summary.warningCount,
 							})
 							return createToolSuccess(
-								formatLintSummary(summary, format),
-								summary,
+								formatLintSummary(output, format),
+								output,
 							)
 						} catch (error) {
 							const failure = toToolFailure(error)
@@ -1134,12 +1268,16 @@ export async function createBiomeServer(
 					},
 					async () => {
 						try {
-							const validatedPath = await validatePathOrDefault(args.path)
-							await ensurePathExists(validatedPath)
-							const result = await runBiomeFix(validatedPath)
+							const pathContext = await resolvePathContextOrDefault(args.path)
+							await ensurePathExists(pathContext.realPath)
+							const result = await runBiomeFix(
+								pathContext.realPath,
+								pathContext.worktreeRoot,
+							)
 							const format = args.response_format
 							lintFixLogger.info('biome_lintFix completed', {
-								path: validatedPath,
+								path: pathContext.realPath,
+								cwd: result.cwd,
 								fixed: result.fixed,
 								remainingErrors: result.remaining.errorCount,
 								remainingWarnings: result.remaining.warningCount,
@@ -1203,12 +1341,16 @@ export async function createBiomeServer(
 					},
 					async () => {
 						try {
-							const validatedPath = await validatePathOrDefault(args.path)
-							await ensurePathExists(validatedPath)
-							const result = await runBiomeFormatCheck(validatedPath)
+							const pathContext = await resolvePathContextOrDefault(args.path)
+							await ensurePathExists(pathContext.realPath)
+							const result = await runBiomeFormatCheck(
+								pathContext.realPath,
+								pathContext.worktreeRoot,
+							)
 							const format = args.response_format
 							formatCheckLogger.info('biome_formatCheck completed', {
-								path: validatedPath,
+								path: pathContext.realPath,
+								cwd: result.cwd,
 								formatted: result.formatted,
 								unformattedCount: result.unformattedFiles.length,
 							})

--- a/packages/bun-runner/README.md
+++ b/packages/bun-runner/README.md
@@ -4,9 +4,9 @@ Bun test runner MCP server for Claude Code. Runs tests with structured, token-ef
 
 ## Tools
 
-- `bun_runTests` — Run tests with optional pattern filter
+- `bun_runTests` — Run tests with optional `pattern` and `cwd`
 - `bun_testFile` — Run specific test file
-- `bun_testCoverage` — Run tests with coverage report
+- `bun_testCoverage` — Run tests with coverage report and optional `cwd`
 
 ## Usage
 
@@ -30,6 +30,21 @@ Or in `.mcp.json`:
 ## Response Format
 
 All tools accept a `response_format` parameter (`"markdown"` or `"json"`). Use `"json"` for token-efficient structured output in agent pipelines.
+
+JSON responses include `cwd`, the directory used to run Bun. Inspect it when
+calling from Codex or other Git worktrees.
+
+## Git Worktrees
+
+The runner accepts paths in the startup checkout and linked Git worktrees that
+share the same Git common dir. Unrelated repositories remain blocked.
+
+```json
+{
+  "cwd": "/path/to/codex-worktree",
+  "response_format": "json"
+}
+```
 
 ## License
 

--- a/packages/bun-runner/mcp/index.test.ts
+++ b/packages/bun-runner/mcp/index.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, spyOn, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import {
@@ -18,12 +21,45 @@ import {
 	MIN_PARENT_CHECK_MS,
 	parseIdleExitMs,
 	parseParentCheckMs,
+	resolvePathContext,
 	SERVER_VERSION,
 	spawnWithTimeout,
 	validatePath,
 	validateShellSafePattern,
 } from './index'
 import { parseBunTestOutput } from './parse-utils'
+
+async function runGit(args: string[], cwd = process.cwd()): Promise<void> {
+	const proc = Bun.spawn(['git', ...args], {
+		cwd,
+		stdout: 'pipe',
+		stderr: 'pipe',
+	})
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	])
+	if (exitCode !== 0) {
+		throw new Error(`git ${args.join(' ')} failed (${exitCode}): ${stdout}${stderr}`)
+	}
+}
+
+async function createLinkedWorktree(prefix: string): Promise<{
+	worktree: string
+	cleanup: () => Promise<void>
+}> {
+	const parent = await mkdtemp(path.join(tmpdir(), `${prefix}-`))
+	const worktree = path.join(parent, 'checkout')
+	await runGit(['worktree', 'add', '--detach', worktree, 'HEAD'])
+	return {
+		worktree,
+		cleanup: async () => {
+			await runGit(['worktree', 'remove', '--force', worktree]).catch(() => undefined)
+			await rm(parent, { recursive: true, force: true })
+		},
+	}
+}
 
 describe('parseBunTestOutput', () => {
 	test('parses all passing tests', () => {
@@ -358,8 +394,75 @@ describe('validation helpers', () => {
 		await expect(validatePath('packages/bun-runner\x00')).rejects.toThrow('Path contains null byte')
 	})
 
+	test('rejects control characters', async () => {
+		await expect(validatePath('packages/bun-runner\n')).rejects.toThrow(
+			'Path contains control characters',
+		)
+	})
+
 	test('rejects traversal paths outside repository', async () => {
-		await expect(validatePath('../../../etc/passwd')).rejects.toThrow('Path outside repository')
+		await expect(validatePath('../../../etc/passwd')).rejects.toThrow(
+			'Path outside configured runner repository or linked worktrees',
+		)
+	})
+
+	test('rejects symlink escape outside repository', async () => {
+		const linkPath = path.join(process.cwd(), 'tmp-bun-outside-link')
+		await rm(linkPath, { force: true })
+		await symlink('/tmp', linkPath)
+		try {
+			await expect(validatePath(linkPath)).rejects.toThrow(
+				'Path outside configured runner repository or linked worktrees',
+			)
+		} finally {
+			await rm(linkPath, { force: true })
+		}
+	})
+
+	test('accepts paths in linked worktrees for the same repository', async () => {
+		_resetGitRootCache()
+		const { worktree, cleanup } = await createLinkedWorktree('bun-runner-linked-worktree')
+		try {
+			const packagePath = path.join(worktree, 'package.json')
+			const context = await resolvePathContext(packagePath)
+
+			expect(context.realPath).toBe(await realpath(packagePath))
+			expect(context.worktreeRoot).toBe(await realpath(worktree))
+		} finally {
+			await cleanup()
+		}
+	})
+
+	test('accepts missing paths under linked worktrees via nearest ancestor', async () => {
+		_resetGitRootCache()
+		const { worktree, cleanup } = await createLinkedWorktree('bun-runner-missing-linked-worktree')
+		try {
+			const missingPath = path.join(worktree, 'reports', 'future.test.ts')
+			const context = await resolvePathContext(missingPath)
+
+			expect(context.realPath).toBe(
+				path.join(await realpath(worktree), 'reports', 'future.test.ts'),
+			)
+			expect(context.worktreeRoot).toBe(await realpath(worktree))
+		} finally {
+			await cleanup()
+		}
+	})
+
+	test('rejects paths in unrelated git repositories', async () => {
+		_resetGitRootCache()
+		const unrelatedRepo = await mkdtemp(path.join(tmpdir(), 'bun-runner-unrelated-repo-'))
+		try {
+			await runGit(['init'], unrelatedRepo)
+			const filePath = path.join(unrelatedRepo, 'index.ts')
+			await writeFile(filePath, 'export const value = 1;\n')
+
+			await expect(validatePath(filePath)).rejects.toThrow(
+				'Path outside configured runner repository or linked worktrees',
+			)
+		} finally {
+			await rm(unrelatedRepo, { recursive: true, force: true })
+		}
 	})
 
 	test('rejects unsafe shell patterns', () => {
@@ -463,6 +566,7 @@ describe('bun tools integration', () => {
 			expect(runTests?.title).toBe('Bun Test Runner')
 			expect(runTests?.annotations?.readOnlyHint).toBe(true)
 			expect(runTests?.outputSchema).toBeDefined()
+			expect(runTests?.inputSchema.properties?.cwd).toBeDefined()
 
 			const testFile = list.tools.find((entry) => entry.name === 'bun_testFile')
 			expect(testFile).toBeDefined()
@@ -475,6 +579,7 @@ describe('bun tools integration', () => {
 			expect(testCoverage?.title).toBe('Bun Test Coverage Reporter')
 			expect(testCoverage?.annotations?.readOnlyHint).toBe(true)
 			expect(testCoverage?.outputSchema).toBeDefined()
+			expect(testCoverage?.inputSchema.properties?.cwd).toBeDefined()
 		} finally {
 			await Promise.all([client.close(), server.close()])
 		}
@@ -501,18 +606,139 @@ describe('bun tools integration', () => {
 			expect(result.structuredContent).toBeDefined()
 
 			const summary = result.structuredContent as {
+				cwd: string
 				passed: number
 				failed: number
 				total: number
 				failures: Array<{ file: string; message: string; line: number | null }>
 			}
 
+			expect(typeof summary.cwd).toBe('string')
 			expect(typeof summary.passed).toBe('number')
 			expect(typeof summary.failed).toBe('number')
 			expect(typeof summary.total).toBe('number')
 			expect(Array.isArray(summary.failures)).toBe(true)
+
+			const text = result.content[0]?.text
+			expect(typeof text).toBe('string')
+			expect(JSON.parse(text as string).cwd).toBe(summary.cwd)
 		} finally {
 			await Promise.all([client.close(), server.close()])
+		}
+	})
+
+	test('bun_testFile runs linked-worktree files from that worktree cwd', async () => {
+		_resetGitRootCache()
+		const { worktree, cleanup } = await createLinkedWorktree('bun-runner-tool-linked-worktree')
+		const fixtureDir = path.join(worktree, 'reports', 'bun-linked-fixture')
+		await mkdir(fixtureDir, { recursive: true })
+		const fixtureFile = path.join(fixtureDir, 'pass.test.ts')
+		await writeFile(
+			fixtureFile,
+			"import { expect, test } from 'bun:test';\ntest('linked file pass', () => expect(1 + 1).toBe(2));\n",
+		)
+
+		const server = await createBunServer()
+		const client = new Client({ name: 'bun-client', version: '0.0.1' })
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+		try {
+			const result = await client.callTool({
+				name: 'bun_testFile',
+				arguments: {
+					file: fixtureFile,
+					response_format: 'json',
+				},
+			})
+
+			expect(result.isError).toBe(false)
+			const output = result.structuredContent as {
+				cwd: string
+				failed: number
+				total: number
+			}
+			expect(output.cwd).toBe(await realpath(worktree))
+			expect(output.failed).toBe(0)
+			expect(output.total).toBe(1)
+			expect(JSON.parse(result.content[0]?.text as string).cwd).toBe(output.cwd)
+		} finally {
+			await Promise.all([client.close(), server.close()])
+			await cleanup()
+		}
+	})
+
+	test('bun_runTests accepts linked-worktree cwd for name filters', async () => {
+		_resetGitRootCache()
+		const { worktree, cleanup } = await createLinkedWorktree('bun-runner-cwd-linked-worktree')
+		const fixtureDir = path.join(worktree, 'reports', 'bun-cwd-fixture')
+		await mkdir(fixtureDir, { recursive: true })
+		await writeFile(
+			path.join(fixtureDir, 'pass.test.ts'),
+			"import { expect, test } from 'bun:test';\ntest('linked cwd unique pass', () => expect(true).toBe(true));\n",
+		)
+
+		const server = await createBunServer()
+		const client = new Client({ name: 'bun-client', version: '0.0.1' })
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+		try {
+			const result = await client.callTool({
+				name: 'bun_runTests',
+				arguments: {
+					cwd: worktree,
+					pattern: 'linked cwd unique pass',
+					response_format: 'json',
+				},
+			})
+
+			expect(result.isError).toBe(false)
+			const output = result.structuredContent as {
+				cwd: string
+				failed: number
+				total: number
+			}
+			expect(output.cwd).toBe(await realpath(worktree))
+			expect(output.failed).toBe(0)
+			expect(output.total).toBe(1)
+		} finally {
+			await Promise.all([client.close(), server.close()])
+			await cleanup()
+		}
+	})
+
+	test('bun_runTests rejects cwd and path pattern from different worktrees', async () => {
+		_resetGitRootCache()
+		const first = await createLinkedWorktree('bun-runner-mixed-first')
+		const second = await createLinkedWorktree('bun-runner-mixed-second')
+		try {
+			const server = await createBunServer()
+			const client = new Client({ name: 'bun-client', version: '0.0.1' })
+			const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+			await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+			try {
+				const result = await client.callTool({
+					name: 'bun_runTests',
+					arguments: {
+						cwd: first.worktree,
+						pattern: path.join(second.worktree, 'package.json'),
+						response_format: 'json',
+					},
+				})
+
+				expect(result.isError).toBe(true)
+				expect(result.content[0]?.text).toContain('PATTERN_INVALID')
+			} finally {
+				await Promise.all([client.close(), server.close()])
+			}
+		} finally {
+			await first.cleanup()
+			await second.cleanup()
 		}
 	})
 

--- a/packages/bun-runner/mcp/index.test.ts
+++ b/packages/bun-runner/mcp/index.test.ts
@@ -449,6 +449,12 @@ describe('validation helpers', () => {
 		}
 	})
 
+	test('rejects file paths when a directory is required', async () => {
+		await expect(resolvePathContext('package.json', { requireDirectory: true })).rejects.toThrow(
+			'cwd must resolve to a directory',
+		)
+	})
+
 	test('rejects paths in unrelated git repositories', async () => {
 		_resetGitRootCache()
 		const unrelatedRepo = await mkdtemp(path.join(tmpdir(), 'bun-runner-unrelated-repo-'))
@@ -496,7 +502,7 @@ describe('createBunInvocation', () => {
 			expect(keys.includes('TMPDIR')).toBe(true)
 			expect(keys.includes('AWS_SECRET_ACCESS_KEY')).toBe(false)
 			expect(keys.includes('GITHUB_TOKEN')).toBe(false)
-			expect(invocation.cmd).toEqual(['bun', 'test', '--', 'auth'])
+			expect(invocation.cmd).toEqual(['bun', 'test', '--test-name-pattern', 'auth'])
 		} finally {
 			if (previousNodePath === undefined) {
 				delete process.env.NODE_PATH
@@ -519,6 +525,16 @@ describe('createBunInvocation', () => {
 	test('builds coverage command with Bun coverage flag', () => {
 		const invocation = createBunCoverageInvocation()
 		expect(invocation.cmd).toEqual(['bun', 'test', '--coverage'])
+	})
+
+	test('uses positional arguments for path-like file patterns', () => {
+		expect(createBunInvocation('login.test.ts').cmd).toEqual(['bun', 'test', '--', 'login.test.ts'])
+		expect(createBunInvocation('tests/login.ts').cmd).toEqual([
+			'bun',
+			'test',
+			'--',
+			'tests/login.ts',
+		])
 	})
 })
 
@@ -689,7 +705,7 @@ describe('bun tools integration', () => {
 			const result = await client.callTool({
 				name: 'bun_runTests',
 				arguments: {
-					cwd: worktree,
+					cwd: fixtureDir,
 					pattern: 'linked cwd unique pass',
 					response_format: 'json',
 				},
@@ -701,12 +717,78 @@ describe('bun tools integration', () => {
 				failed: number
 				total: number
 			}
-			expect(output.cwd).toBe(await realpath(worktree))
+			expect(output.cwd).toBe(await realpath(fixtureDir))
 			expect(output.failed).toBe(0)
 			expect(output.total).toBe(1)
 		} finally {
 			await Promise.all([client.close(), server.close()])
 			await cleanup()
+		}
+	})
+
+	test('bun_runTests preserves subdirectory cwd for path patterns', async () => {
+		_resetGitRootCache()
+		const fixtureDir = path.join(process.cwd(), 'reports', 'bun-subdir-cwd-fixture')
+		await rm(fixtureDir, { recursive: true, force: true })
+		await mkdir(path.join(fixtureDir, 'tests'), { recursive: true })
+		await writeFile(
+			path.join(fixtureDir, 'tests', 'pass.test.ts'),
+			"import { expect, test } from 'bun:test';\ntest('subdir cwd unique pass', () => expect(true).toBe(true));\n",
+		)
+
+		const server = await createBunServer()
+		const client = new Client({ name: 'bun-client', version: '0.0.1' })
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+		try {
+			const result = await client.callTool({
+				name: 'bun_runTests',
+				arguments: {
+					cwd: fixtureDir,
+					pattern: 'tests/pass.test.ts',
+					response_format: 'json',
+				},
+			})
+
+			expect(result.isError).toBe(false)
+			const output = result.structuredContent as {
+				cwd: string
+				failed: number
+				total: number
+			}
+			expect(output.cwd).toBe(await realpath(fixtureDir))
+			expect(output.failed).toBe(0)
+			expect(output.total).toBe(1)
+		} finally {
+			await Promise.all([client.close(), server.close()])
+			await rm(fixtureDir, { recursive: true, force: true })
+		}
+	})
+
+	test('bun_runTests rejects file paths as cwd', async () => {
+		_resetGitRootCache()
+		const server = await createBunServer()
+		const client = new Client({ name: 'bun-client', version: '0.0.1' })
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+		try {
+			const result = await client.callTool({
+				name: 'bun_runTests',
+				arguments: {
+					cwd: 'package.json',
+					pattern: 'nonesuchpattern',
+					response_format: 'json',
+				},
+			})
+
+			expect(result.isError).toBe(true)
+			expect(result.content[0]?.text).toContain('CWD_INVALID')
+		} finally {
+			await Promise.all([client.close(), server.close()])
 		}
 	})
 

--- a/packages/bun-runner/mcp/index.test.ts
+++ b/packages/bun-runner/mcp/index.test.ts
@@ -862,16 +862,17 @@ describe('parseParentCheckMs', () => {
 })
 
 describe('parseIdleExitMs', () => {
-	test('returns default when env is undefined', () => {
+	test('returns default disabled value when env is undefined', () => {
+		expect(DEFAULT_IDLE_EXIT_MS).toBe(0)
 		expect(parseIdleExitMs(undefined)).toBe(DEFAULT_IDLE_EXIT_MS)
 	})
 
-	test('returns default for empty / whitespace string', () => {
+	test('returns default disabled value for empty / whitespace string', () => {
 		expect(parseIdleExitMs('')).toBe(DEFAULT_IDLE_EXIT_MS)
 		expect(parseIdleExitMs('   ')).toBe(DEFAULT_IDLE_EXIT_MS)
 	})
 
-	test('returns default for non-numeric / NaN values', () => {
+	test('returns default disabled value for non-numeric / NaN values', () => {
 		expect(parseIdleExitMs('abc')).toBe(DEFAULT_IDLE_EXIT_MS)
 		expect(parseIdleExitMs('NaN')).toBe(DEFAULT_IDLE_EXIT_MS)
 	})
@@ -894,23 +895,19 @@ describe('parseIdleExitMs', () => {
 })
 
 describe('createIdleShutdownWatcherFromEnv', () => {
-	test('uses the default idle timeout when env is omitted', () => {
+	test('leaves idle shutdown disabled when env is omitted', () => {
 		const calls: number[] = []
-		const fakeWatcher = {
-			recordRequestStart: () => () => {},
-			stop: () => {},
-		}
 		const result = createIdleShutdownWatcherFromEnv({
 			env: {},
 			onIdle: () => {},
 			createWatcher: (opts) => {
 				calls.push(opts.idleMs)
-				return fakeWatcher
+				return undefined
 			},
 		})
 
 		expect(result.idleMs).toBe(DEFAULT_IDLE_EXIT_MS)
-		expect(result.watcher).toBe(fakeWatcher)
+		expect(result.watcher).toBeUndefined()
 		expect(calls).toEqual([DEFAULT_IDLE_EXIT_MS])
 	})
 

--- a/packages/bun-runner/mcp/index.ts
+++ b/packages/bun-runner/mcp/index.ts
@@ -10,7 +10,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { readFileSync } from 'node:fs'
-import { realpath } from 'node:fs/promises'
+import { realpath, stat } from 'node:fs/promises'
 import path from 'node:path'
 import {
 	configure,
@@ -182,7 +182,7 @@ const failureSchema: z.ZodObject<{
 	stack: z.string().optional().nullable(),
 })
 
-const testSummarySchema: z.ZodObject<{
+const testSummaryCoreSchema: z.ZodObject<{
 	passed: z.ZodNumber
 	failed: z.ZodNumber
 	total: z.ZodNumber
@@ -194,6 +194,10 @@ const testSummarySchema: z.ZodObject<{
 	failures: z.array(failureSchema),
 })
 
+const testSummarySchema = testSummaryCoreSchema.extend({
+	cwd: z.string(),
+})
+
 const coverageFileSchema: z.ZodObject<{
 	file: z.ZodString
 	percent: z.ZodNumber
@@ -203,13 +207,15 @@ const coverageFileSchema: z.ZodObject<{
 })
 
 const testCoverageSchema: z.ZodObject<{
-	summary: typeof testSummarySchema
+	cwd: z.ZodString
+	summary: typeof testSummaryCoreSchema
 	coverage: z.ZodObject<{
 		percent: z.ZodNumber
 		uncovered: z.ZodArray<typeof coverageFileSchema>
 	}>
 }> = z.object({
-	summary: testSummarySchema,
+	cwd: z.string(),
+	summary: testSummaryCoreSchema,
 	coverage: z.object({
 		percent: z.number(),
 		uncovered: z.array(coverageFileSchema),
@@ -228,6 +234,19 @@ const PACKAGE_VERSION: string = JSON.parse(
 export const SERVER_VERSION: string = PACKAGE_VERSION
 
 let _gitRootPromise: Promise<string> | null = null
+let _repositoryContextPromise: Promise<RepositoryContext> | null = null
+
+interface RepositoryContext {
+	worktreeRoot: string
+	gitCommonDir: string
+}
+
+interface PathContext {
+	realPath: string
+	worktreeRoot: string
+	startupRoot: string
+	gitCommonDir: string
+}
 
 /**
  * Get the git root once per process using promise coalescing.
@@ -239,12 +258,36 @@ export function getGitRoot(): Promise<string> {
 	if (_gitRootPromise !== null) {
 		return _gitRootPromise
 	}
-	_gitRootPromise = resolveGitRoot()
+	_gitRootPromise = getStartupRepositoryContext().then(
+		(context) => context.worktreeRoot,
+	)
 	return _gitRootPromise
 }
 
-async function resolveGitRoot(): Promise<string> {
-	const proc = Bun.spawn(['git', 'rev-parse', '--show-toplevel'], {
+async function getStartupRepositoryContext(): Promise<RepositoryContext> {
+	if (_repositoryContextPromise !== null) {
+		return _repositoryContextPromise
+	}
+	_repositoryContextPromise = resolveRepositoryContext(process.cwd())
+	return _repositoryContextPromise
+}
+
+async function resolveRepositoryContext(
+	cwd: string,
+): Promise<RepositoryContext> {
+	const [worktreeRoot, gitCommonDir] = await Promise.all([
+		resolveGitPath(cwd, ['--show-toplevel']),
+		resolveGitPath(cwd, ['--path-format=absolute', '--git-common-dir']),
+	])
+
+	return {
+		worktreeRoot: await realpath(worktreeRoot),
+		gitCommonDir: await realpath(gitCommonDir),
+	}
+}
+
+async function resolveGitPath(cwd: string, args: string[]): Promise<string> {
+	const proc = Bun.spawn(['git', '-C', cwd, 'rev-parse', ...args], {
 		stdout: 'pipe',
 		stderr: 'pipe',
 	})
@@ -258,7 +301,7 @@ async function resolveGitRoot(): Promise<string> {
 		throw new Error('Not inside a git repository')
 	}
 
-	return realpath(stdout.trim())
+	return stdout.trim()
 }
 
 /**
@@ -266,6 +309,7 @@ async function resolveGitRoot(): Promise<string> {
  */
 export function _resetGitRootCache(): void {
 	_gitRootPromise = null
+	_repositoryContextPromise = null
 }
 
 /**
@@ -274,6 +318,13 @@ export function _resetGitRootCache(): void {
  * Why: test file/path inputs are user-controlled and must not escape the repo.
  */
 export async function validatePath(inputPath: string): Promise<string> {
+	return (await resolvePathContext(inputPath)).realPath
+}
+
+export async function resolvePathContext(
+	inputPath: string,
+	options?: { baseDir?: string },
+): Promise<PathContext> {
 	if (inputPath.includes('\x00')) {
 		throw new Error('Path contains null byte')
 	}
@@ -286,26 +337,63 @@ export async function validatePath(inputPath: string): Promise<string> {
 		throw new Error('Path cannot be empty')
 	}
 
-	const resolvedPath = path.resolve(inputPath)
+	const resolvedPath = path.resolve(
+		options?.baseDir ?? process.cwd(),
+		inputPath,
+	)
 	let realInputPath: string
+	let nearestExistingDir: string
 
 	try {
 		realInputPath = await realpath(resolvedPath)
+		nearestExistingDir = (await stat(realInputPath)).isDirectory()
+			? realInputPath
+			: path.dirname(realInputPath)
 	} catch (error) {
 		const err = error as NodeJS.ErrnoException
 		if (err.code === 'ENOENT') {
-			realInputPath = await resolveNearestAncestor(resolvedPath)
+			const resolved = await resolveNearestAncestor(resolvedPath)
+			realInputPath = resolved.realPath
+			nearestExistingDir = resolved.nearestExistingDir
 		} else {
 			throw new Error(`Cannot resolve path: ${err.message}`)
 		}
 	}
 
-	const gitRoot = await getGitRoot()
-	if (realInputPath !== gitRoot && !realInputPath.startsWith(`${gitRoot}/`)) {
-		throw new Error(`Path outside repository: ${inputPath}`)
+	const startupContext = await getStartupRepositoryContext()
+	if (isPathInsideOrEqual(realInputPath, startupContext.worktreeRoot)) {
+		return {
+			realPath: realInputPath,
+			worktreeRoot: startupContext.worktreeRoot,
+			startupRoot: startupContext.worktreeRoot,
+			gitCommonDir: startupContext.gitCommonDir,
+		}
 	}
 
-	return realInputPath
+	let targetContext: RepositoryContext
+	try {
+		targetContext = await resolveRepositoryContext(nearestExistingDir)
+	} catch {
+		throw new Error(
+			`Path outside configured runner repository or linked worktrees: ${inputPath}`,
+		)
+	}
+
+	if (
+		targetContext.gitCommonDir === startupContext.gitCommonDir &&
+		isPathInsideOrEqual(realInputPath, targetContext.worktreeRoot)
+	) {
+		return {
+			realPath: realInputPath,
+			worktreeRoot: targetContext.worktreeRoot,
+			startupRoot: startupContext.worktreeRoot,
+			gitCommonDir: targetContext.gitCommonDir,
+		}
+	}
+
+	throw new Error(
+		`Path outside configured runner repository or linked worktrees: ${inputPath}`,
+	)
 }
 
 /**
@@ -315,7 +403,10 @@ export async function validatePath(inputPath: string): Promise<string> {
  * Why: a naive fallback to path.resolve on ENOENT misses intermediate symlinks
  * that could escape the repository boundary.
  */
-async function resolveNearestAncestor(resolvedPath: string): Promise<string> {
+async function resolveNearestAncestor(resolvedPath: string): Promise<{
+	realPath: string
+	nearestExistingDir: string
+}> {
 	let dir = path.dirname(resolvedPath)
 	const suffix = path.basename(resolvedPath)
 	const segments: string[] = [suffix]
@@ -323,14 +414,30 @@ async function resolveNearestAncestor(resolvedPath: string): Promise<string> {
 	while (dir !== path.dirname(dir)) {
 		try {
 			const realDir = await realpath(dir)
-			return path.join(realDir, ...segments)
+			return {
+				realPath: path.join(realDir, ...segments),
+				nearestExistingDir: realDir,
+			}
 		} catch {
 			segments.unshift(path.basename(dir))
 			dir = path.dirname(dir)
 		}
 	}
 
-	return resolvedPath
+	return {
+		realPath: resolvedPath,
+		nearestExistingDir: path.dirname(resolvedPath),
+	}
+}
+
+function isPathInsideOrEqual(candidatePath: string, rootPath: string): boolean {
+	const relative = path.relative(rootPath, candidatePath)
+	return (
+		relative === '' ||
+		(relative.length > 0 &&
+			!relative.startsWith('..') &&
+			!path.isAbsolute(relative))
+	)
 }
 
 /**
@@ -383,7 +490,7 @@ function hasShellUnsafeCharacters(value: string): boolean {
 
 function normalizeSummary(
 	summary: TestSummary,
-): z.infer<typeof testSummarySchema> {
+): z.infer<typeof testSummaryCoreSchema> {
 	return {
 		passed: summary.passed,
 		failed: summary.failed,
@@ -627,6 +734,7 @@ export async function spawnWithTimeout(
 	cmd: string[],
 	timeoutMs: number,
 	options?: {
+		cwd?: string
 		env?: Record<string, string>
 		maxBytes?: number
 	},
@@ -641,6 +749,7 @@ export async function spawnWithTimeout(
 	const proc = (() => {
 		try {
 			return Bun.spawn(cmd, {
+				cwd: options?.cwd,
 				env: options?.env,
 				stdout: 'pipe',
 				stderr: 'pipe',
@@ -693,6 +802,7 @@ export async function spawnWithTimeout(
  */
 async function runBunTests(
 	pattern?: string,
+	cwd = process.cwd(),
 ): Promise<z.infer<typeof testSummarySchema>> {
 	const invocation = createBunInvocation(pattern)
 
@@ -704,6 +814,7 @@ async function runBunTests(
 		stdoutTruncated,
 		stderrTruncated,
 	} = await spawnWithTimeout(invocation.cmd, TEST_TIMEOUT_MS, {
+		cwd,
 		env: invocation.env,
 	})
 
@@ -729,6 +840,7 @@ async function runBunTests(
 			failed: 0,
 			total: passed,
 			failures: [],
+			cwd,
 		}
 	}
 
@@ -744,12 +856,15 @@ async function runBunTests(
 		)
 	}
 
-	return normalizeSummary(parseBunTestOutput(output))
+	return {
+		...normalizeSummary(parseBunTestOutput(output)),
+		cwd,
+	}
 }
 
-async function runBunTestCoverage(): Promise<
-	z.infer<typeof testCoverageSchema>
-> {
+async function runBunTestCoverage(
+	cwd = process.cwd(),
+): Promise<z.infer<typeof testCoverageSchema>> {
 	const invocation = createBunCoverageInvocation()
 	const {
 		stdout,
@@ -759,6 +874,7 @@ async function runBunTestCoverage(): Promise<
 		stdoutTruncated,
 		stderrTruncated,
 	} = await spawnWithTimeout(invocation.cmd, COVERAGE_TIMEOUT_MS, {
+		cwd,
 		env: invocation.env,
 	})
 
@@ -801,13 +917,14 @@ async function runBunTestCoverage(): Promise<
 	}
 
 	return {
+		cwd,
 		summary,
 		coverage: { percent, uncovered },
 	}
 }
 
 function formatTestSummary(
-	summary: z.infer<typeof testSummarySchema>,
+	summary: z.infer<typeof testSummaryCoreSchema> & { cwd?: string },
 	format: 'markdown' | 'json',
 	context?: string,
 ): string {
@@ -868,13 +985,14 @@ export function extractTopStackFrame(stack: string): string {
 }
 
 export function compactSummaryForJsonText(
-	summary: z.infer<typeof testSummarySchema>,
+	summary: z.infer<typeof testSummaryCoreSchema> & { cwd?: string },
 ): Record<string, unknown> {
 	const commonFile = getCommonFailureFile(summary.failures)
 	if (!commonFile) {
 		return stripNullishDeep(summary)
 	}
 	return stripNullishDeep({
+		cwd: summary.cwd,
 		passed: summary.passed,
 		failed: summary.failed,
 		total: summary.total,
@@ -910,6 +1028,46 @@ function formatCoverageResult(
 	}
 
 	return output.trim()
+}
+
+async function getDefaultExecutionCwd(): Promise<string> {
+	return realpath(process.cwd())
+}
+
+function isPathLikePattern(pattern: string): boolean {
+	return pattern.includes('/') || pattern.includes('..')
+}
+
+async function resolveRunTestsContext(args: {
+	pattern?: string
+	cwd?: string
+}): Promise<{ pattern?: string; cwd: string }> {
+	const cwdContext = args.cwd ? await resolvePathContext(args.cwd) : undefined
+	const patternContext =
+		args.pattern && isPathLikePattern(args.pattern)
+			? await resolvePathContext(args.pattern, {
+					baseDir: cwdContext?.worktreeRoot ?? process.cwd(),
+				})
+			: undefined
+
+	if (
+		cwdContext &&
+		patternContext &&
+		cwdContext.worktreeRoot !== patternContext.worktreeRoot
+	) {
+		throw new BunToolError(
+			'PATTERN_INVALID',
+			'Pattern path and cwd must resolve to the same worktree',
+		)
+	}
+
+	return {
+		pattern: args.pattern,
+		cwd:
+			cwdContext?.worktreeRoot ??
+			patternContext?.worktreeRoot ??
+			(await getDefaultExecutionCwd()),
+	}
 }
 
 /**
@@ -966,6 +1124,13 @@ export async function createBunServer(
 			description:
 				'Run Bun tests for suite-level regression checks. Returns pass/fail counts and structured failures. Read-only. No fixes or coverage. Use bun_testFile for one file; bun_testCoverage for coverage.',
 			inputSchema: z.object({
+				cwd: z
+					.string()
+					.max(4096)
+					.optional()
+					.describe(
+						'Working directory inside startup checkout or a linked worktree',
+					),
 				pattern: z
 					.string()
 					.max(4096)
@@ -1000,14 +1165,16 @@ export async function createBunServer(
 							const pattern = args.pattern
 							if (pattern) {
 								validateShellSafePattern(pattern)
-								if (pattern.includes('/') || pattern.includes('..')) {
-									await validatePath(pattern)
-								}
 							}
 
-							const summary = await runBunTests(pattern)
+							const context = await resolveRunTestsContext({
+								pattern,
+								cwd: args.cwd,
+							})
+							const summary = await runBunTests(context.pattern, context.cwd)
 							const format = args.response_format ?? 'json'
 							runTestsLogger.info('bun_runTests completed', {
+								cwd: summary.cwd,
 								passed: summary.passed,
 								failed: summary.failed,
 								total: summary.total,
@@ -1067,11 +1234,15 @@ export async function createBunServer(
 					},
 					async () => {
 						try {
-							const validatedFile = await validatePath(args.file)
-							const summary = await runBunTests(validatedFile)
+							const fileContext = await resolvePathContext(args.file)
+							const summary = await runBunTests(
+								fileContext.realPath,
+								fileContext.worktreeRoot,
+							)
 							const format = args.response_format ?? 'json'
 							testFileLogger.info('bun_testFile completed', {
 								file: args.file,
+								cwd: summary.cwd,
 								passed: summary.passed,
 								failed: summary.failed,
 							})
@@ -1103,6 +1274,13 @@ export async function createBunServer(
 			description:
 				'Run Bun tests with coverage. Returns test summary, coverage percent, and low-coverage files. Read-only and slower than bun_runTests. No fixes. Use bun_runTests for faster no-coverage checks.',
 			inputSchema: z.object({
+				cwd: z
+					.string()
+					.max(4096)
+					.optional()
+					.describe(
+						'Working directory inside startup checkout or a linked worktree',
+					),
 				response_format: z
 					.enum(['markdown', 'json'])
 					.optional()
@@ -1127,9 +1305,13 @@ export async function createBunServer(
 					},
 					async () => {
 						try {
-							const result = await runBunTestCoverage()
+							const cwd = args.cwd
+								? (await resolvePathContext(args.cwd)).worktreeRoot
+								: await getDefaultExecutionCwd()
+							const result = await runBunTestCoverage(cwd)
 							const format = args.response_format ?? 'json'
 							coverageLogger.info('bun_testCoverage completed', {
+								cwd: result.cwd,
 								failed: result.summary.failed,
 								passed: result.summary.passed,
 								coveragePercent: result.coverage.percent,

--- a/packages/bun-runner/mcp/index.ts
+++ b/packages/bun-runner/mcp/index.ts
@@ -1356,8 +1356,11 @@ export const MIN_PARENT_CHECK_MS = 50
 
 /**
  * Default idle shutdown interval in milliseconds.
+ *
+ * Zero keeps runners available unless the host opts into idle cleanup with
+ * MCP_IDLE_EXIT_MS.
  */
-export const DEFAULT_IDLE_EXIT_MS = 900_000
+export const DEFAULT_IDLE_EXIT_MS = 0
 
 /**
  * Lower bound for the idle interval to prevent event-loop saturation.
@@ -1527,8 +1530,8 @@ interface IdleExitEnv {
 /**
  * Create idle shutdown wiring from process-style environment values.
  *
- * Why: startBunServer should exercise the same default-on / disabled parsing
- * as unit tests without making runtime smoke wait for the 15-minute default.
+ * Why: startBunServer should exercise the same opt-in / disabled parsing as
+ * unit tests.
  */
 export function createIdleShutdownWatcherFromEnv(opts: {
 	env: IdleExitEnv

--- a/packages/bun-runner/mcp/index.ts
+++ b/packages/bun-runner/mcp/index.ts
@@ -69,6 +69,7 @@ const TOOL_ERROR_CODES = [
 	'TIMEOUT',
 	'SPAWN_FAILURE',
 	'PATTERN_INVALID',
+	'CWD_INVALID',
 ] as const
 
 type ToolErrorCode = (typeof TOOL_ERROR_CODES)[number]
@@ -323,7 +324,7 @@ export async function validatePath(inputPath: string): Promise<string> {
 
 export async function resolvePathContext(
 	inputPath: string,
-	options?: { baseDir?: string },
+	options?: { baseDir?: string; requireDirectory?: boolean },
 ): Promise<PathContext> {
 	if (inputPath.includes('\x00')) {
 		throw new Error('Path contains null byte')
@@ -343,10 +344,12 @@ export async function resolvePathContext(
 	)
 	let realInputPath: string
 	let nearestExistingDir: string
+	let inputIsDirectory = false
 
 	try {
 		realInputPath = await realpath(resolvedPath)
-		nearestExistingDir = (await stat(realInputPath)).isDirectory()
+		inputIsDirectory = (await stat(realInputPath)).isDirectory()
+		nearestExistingDir = inputIsDirectory
 			? realInputPath
 			: path.dirname(realInputPath)
 	} catch (error) {
@@ -358,6 +361,13 @@ export async function resolvePathContext(
 		} else {
 			throw new Error(`Cannot resolve path: ${err.message}`)
 		}
+	}
+
+	if (options?.requireDirectory && !inputIsDirectory) {
+		throw new BunToolError(
+			'CWD_INVALID',
+			`cwd must resolve to a directory: ${inputPath}`,
+		)
 	}
 
 	const startupContext = await getStartupRepositoryContext()
@@ -544,7 +554,11 @@ export function createBunInvocation(pattern?: string): {
 	}
 
 	return {
-		cmd: pattern ? ['bun', 'test', '--', pattern] : ['bun', 'test'],
+		cmd: pattern
+			? isPathLikePattern(pattern)
+				? ['bun', 'test', '--', pattern]
+				: ['bun', 'test', '--test-name-pattern', pattern]
+			: ['bun', 'test'],
 		env,
 	}
 }
@@ -1035,18 +1049,25 @@ async function getDefaultExecutionCwd(): Promise<string> {
 }
 
 function isPathLikePattern(pattern: string): boolean {
-	return pattern.includes('/') || pattern.includes('..')
+	return (
+		pattern.includes('/') ||
+		pattern.includes('..') ||
+		/\.(?:test|spec)\.[cm]?[jt]sx?$/.test(pattern) ||
+		/\.[cm]?[jt]sx?$/.test(pattern)
+	)
 }
 
 async function resolveRunTestsContext(args: {
 	pattern?: string
 	cwd?: string
 }): Promise<{ pattern?: string; cwd: string }> {
-	const cwdContext = args.cwd ? await resolvePathContext(args.cwd) : undefined
+	const cwdContext = args.cwd
+		? await resolvePathContext(args.cwd, { requireDirectory: true })
+		: undefined
 	const patternContext =
 		args.pattern && isPathLikePattern(args.pattern)
 			? await resolvePathContext(args.pattern, {
-					baseDir: cwdContext?.worktreeRoot ?? process.cwd(),
+					baseDir: cwdContext?.realPath ?? process.cwd(),
 				})
 			: undefined
 
@@ -1064,7 +1085,7 @@ async function resolveRunTestsContext(args: {
 	return {
 		pattern: args.pattern,
 		cwd:
-			cwdContext?.worktreeRoot ??
+			cwdContext?.realPath ??
 			patternContext?.worktreeRoot ??
 			(await getDefaultExecutionCwd()),
 	}
@@ -1136,7 +1157,7 @@ export async function createBunServer(
 					.max(4096)
 					.optional()
 					.describe(
-						"File pattern or test name to filter tests (e.g., 'auth' or 'login.test.ts')",
+						"Path-like file pattern or test name regex to filter tests (e.g., 'auth' or 'login.test.ts')",
 					),
 				response_format: z
 					.enum(['markdown', 'json'])
@@ -1306,7 +1327,11 @@ export async function createBunServer(
 					async () => {
 						try {
 							const cwd = args.cwd
-								? (await resolvePathContext(args.cwd)).worktreeRoot
+								? (
+										await resolvePathContext(args.cwd, {
+											requireDirectory: true,
+										})
+									).realPath
 								: await getDefaultExecutionCwd()
 							const result = await runBunTestCoverage(cwd)
 							const format = args.response_format ?? 'json'

--- a/packages/tsc-runner/README.md
+++ b/packages/tsc-runner/README.md
@@ -29,6 +29,23 @@ Or in `.mcp.json`:
 
 All tools accept a `response_format` parameter (`"markdown"` or `"json"`). Use `"json"` for token-efficient structured output in agent pipelines.
 
+JSON responses include `cwd`, the directory used to run TypeScript from the
+nearest config. Inspect it when passing absolute paths from Codex or other Git
+worktrees.
+
+## Git Worktrees
+
+The runner accepts paths in the startup checkout and linked Git worktrees that
+share the same Git common dir. Config discovery stays bounded to the selected
+worktree, and unrelated repositories remain blocked.
+
+```json
+{
+  "path": "/path/to/codex-worktree/packages/app/src/index.ts",
+  "response_format": "json"
+}
+```
+
 ## License
 
 MIT

--- a/packages/tsc-runner/mcp/index.test.ts
+++ b/packages/tsc-runner/mcp/index.test.ts
@@ -831,16 +831,17 @@ describe('parseParentCheckMs', () => {
 })
 
 describe('parseIdleExitMs', () => {
-	test('returns default when env is undefined', () => {
+	test('returns default disabled value when env is undefined', () => {
+		expect(DEFAULT_IDLE_EXIT_MS).toBe(0)
 		expect(parseIdleExitMs(undefined)).toBe(DEFAULT_IDLE_EXIT_MS)
 	})
 
-	test('returns default for empty / whitespace string', () => {
+	test('returns default disabled value for empty / whitespace string', () => {
 		expect(parseIdleExitMs('')).toBe(DEFAULT_IDLE_EXIT_MS)
 		expect(parseIdleExitMs('   ')).toBe(DEFAULT_IDLE_EXIT_MS)
 	})
 
-	test('returns default for non-numeric / NaN values', () => {
+	test('returns default disabled value for non-numeric / NaN values', () => {
 		expect(parseIdleExitMs('abc')).toBe(DEFAULT_IDLE_EXIT_MS)
 		expect(parseIdleExitMs('NaN')).toBe(DEFAULT_IDLE_EXIT_MS)
 	})
@@ -863,23 +864,19 @@ describe('parseIdleExitMs', () => {
 })
 
 describe('createIdleShutdownWatcherFromEnv', () => {
-	test('uses the default idle timeout when env is omitted', () => {
+	test('leaves idle shutdown disabled when env is omitted', () => {
 		const calls: number[] = []
-		const fakeWatcher = {
-			recordRequestStart: () => () => {},
-			stop: () => {},
-		}
 		const result = createIdleShutdownWatcherFromEnv({
 			env: {},
 			onIdle: () => {},
 			createWatcher: (opts) => {
 				calls.push(opts.idleMs)
-				return fakeWatcher
+				return undefined
 			},
 		})
 
 		expect(result.idleMs).toBe(DEFAULT_IDLE_EXIT_MS)
-		expect(result.watcher).toBe(fakeWatcher)
+		expect(result.watcher).toBeUndefined()
 		expect(calls).toEqual([DEFAULT_IDLE_EXIT_MS])
 	})
 

--- a/packages/tsc-runner/mcp/index.test.ts
+++ b/packages/tsc-runner/mcp/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, spyOn, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
-import { rm, symlink } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
@@ -23,11 +24,44 @@ import {
 	parseIdleExitMs,
 	parseParentCheckMs,
 	parseTscOutput,
+	resolvePathContext,
 	SERVER_VERSION,
 	spawnWithTimeout,
 	validatePath,
 	validatePathOrDefault,
 } from './index'
+
+async function runGit(args: string[], cwd = process.cwd()): Promise<void> {
+	const proc = Bun.spawn(['git', ...args], {
+		cwd,
+		stdout: 'pipe',
+		stderr: 'pipe',
+	})
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	])
+	if (exitCode !== 0) {
+		throw new Error(`git ${args.join(' ')} failed (${exitCode}): ${stdout}${stderr}`)
+	}
+}
+
+async function createLinkedWorktree(prefix: string): Promise<{
+	worktree: string
+	cleanup: () => Promise<void>
+}> {
+	const parent = await mkdtemp(path.join(tmpdir(), `${prefix}-`))
+	const worktree = path.join(parent, 'checkout')
+	await runGit(['worktree', 'add', '--detach', worktree, 'HEAD'])
+	return {
+		worktree,
+		cleanup: async () => {
+			await runGit(['worktree', 'remove', '--force', worktree]).catch(() => undefined)
+			await rm(parent, { recursive: true, force: true })
+		},
+	}
+}
 
 function createCaptureWritableStream(chunks: string[]): WritableStream {
 	const decoder = new TextDecoder()
@@ -340,7 +374,9 @@ describe('path validation', () => {
 	})
 
 	test('rejects traversal paths outside repository', async () => {
-		await expect(validatePath('../../../etc/passwd')).rejects.toThrow('Path outside repository')
+		await expect(validatePath('../../../etc/passwd')).rejects.toThrow(
+			'Path outside configured runner repository or linked worktrees',
+		)
 	})
 
 	test('rejects symlink escape outside repository', async () => {
@@ -348,9 +384,55 @@ describe('path validation', () => {
 		await rm(linkPath, { force: true })
 		await symlink('/tmp', linkPath)
 		try {
-			await expect(validatePath(linkPath)).rejects.toThrow('Path outside repository')
+			await expect(validatePath(linkPath)).rejects.toThrow(
+				'Path outside configured runner repository or linked worktrees',
+			)
 		} finally {
 			await rm(linkPath, { force: true })
+		}
+	})
+
+	test('accepts paths in linked worktrees for the same repository', async () => {
+		_resetGitRootCache()
+		const { worktree, cleanup } = await createLinkedWorktree('tsc-runner-linked-worktree')
+		try {
+			const packagePath = path.join(worktree, 'package.json')
+			const context = await resolvePathContext(packagePath)
+
+			expect(context.realPath).toBe(await realpath(packagePath))
+			expect(context.worktreeRoot).toBe(await realpath(worktree))
+		} finally {
+			await cleanup()
+		}
+	})
+
+	test('accepts missing paths under linked worktrees via nearest ancestor', async () => {
+		_resetGitRootCache()
+		const { worktree, cleanup } = await createLinkedWorktree('tsc-runner-missing-linked-worktree')
+		try {
+			const missingPath = path.join(worktree, 'reports', 'future.ts')
+			const context = await resolvePathContext(missingPath)
+
+			expect(context.realPath).toBe(path.join(await realpath(worktree), 'reports', 'future.ts'))
+			expect(context.worktreeRoot).toBe(await realpath(worktree))
+		} finally {
+			await cleanup()
+		}
+	})
+
+	test('rejects paths in unrelated git repositories', async () => {
+		_resetGitRootCache()
+		const unrelatedRepo = await mkdtemp(path.join(tmpdir(), 'tsc-runner-unrelated-repo-'))
+		try {
+			await runGit(['init'], unrelatedRepo)
+			const filePath = path.join(unrelatedRepo, 'index.ts')
+			await writeFile(filePath, 'export const value = 1;\n')
+
+			await expect(validatePath(filePath)).rejects.toThrow(
+				'Path outside configured runner repository or linked worktrees',
+			)
+		} finally {
+			await rm(unrelatedRepo, { recursive: true, force: true })
 		}
 	})
 })
@@ -427,6 +509,96 @@ describe('tsc_check integration', () => {
 			expect(Array.isArray(output.errors)).toBe(true)
 		} finally {
 			await Promise.all([client.close(), server.close()])
+		}
+	})
+
+	test('tsc_check runs linked-worktree paths from that worktree cwd', async () => {
+		_resetGitRootCache()
+		const { worktree, cleanup } = await createLinkedWorktree('tsc-runner-tool-linked-worktree')
+		const fixtureDir = path.join(worktree, 'reports', 'tsc-linked-fixture')
+		await mkdir(fixtureDir, { recursive: true })
+		await writeFile(
+			path.join(fixtureDir, 'tsconfig.json'),
+			JSON.stringify(
+				{
+					compilerOptions: {
+						target: 'ES2022',
+						module: 'NodeNext',
+						moduleResolution: 'NodeNext',
+						strict: true,
+						noEmit: true,
+						skipLibCheck: true,
+						types: [],
+					},
+				},
+				null,
+				2,
+			),
+		)
+		await writeFile(path.join(fixtureDir, 'index.ts'), 'const ok = 1;\n')
+		const server = await createTscServer()
+		const client = new Client({ name: 'tsc-client', version: '0.0.1' })
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+		try {
+			const result = await client.callTool({
+				name: 'tsc_check',
+				arguments: {
+					path: fixtureDir,
+					response_format: 'json',
+				},
+			})
+
+			expect(result.isError).toBe(false)
+			const output = result.structuredContent as {
+				cwd: string
+				errorCount: number
+			}
+			expect(output.cwd).toBe(await realpath(fixtureDir))
+			expect(output.cwd.startsWith(await realpath(worktree))).toBe(true)
+			expect(output.errorCount).toBe(0)
+			expect(JSON.parse(result.content[0]?.text as string).cwd).toBe(output.cwd)
+		} finally {
+			await Promise.all([client.close(), server.close()])
+			await cleanup()
+		}
+	})
+
+	test('CONFIG_NOT_FOUND is bounded to the linked worktree', async () => {
+		_resetGitRootCache()
+		const { worktree, cleanup } = await createLinkedWorktree('tsc-runner-no-config-linked-worktree')
+		await rm(path.join(worktree, 'tsconfig.json'), { force: true })
+		const fixtureDir = path.join(worktree, 'reports', 'no-config')
+		await mkdir(fixtureDir, { recursive: true })
+
+		const server = await createTscServer()
+		const client = new Client({ name: 'tsc-client', version: '0.0.1' })
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+		try {
+			const result = await client.callTool({
+				name: 'tsc_check',
+				arguments: {
+					path: fixtureDir,
+					response_format: 'json',
+				},
+			})
+
+			expect(result.isError).toBe(true)
+			expect(result.content[0]?.text).toContain('CONFIG_NOT_FOUND')
+			const output = result.structuredContent as {
+				cwd: string
+				errors: Array<{ code: string }>
+			}
+			expect(output.cwd).toBe(await realpath(worktree))
+			expect(output.errors[0]?.code).toBe('CONFIG_NOT_FOUND')
+		} finally {
+			await Promise.all([client.close(), server.close()])
+			await cleanup()
 		}
 	})
 

--- a/packages/tsc-runner/mcp/index.ts
+++ b/packages/tsc-runner/mcp/index.ts
@@ -1273,8 +1273,11 @@ export const MIN_PARENT_CHECK_MS = 50
 
 /**
  * Default idle shutdown interval in milliseconds.
+ *
+ * Zero keeps runners available unless the host opts into idle cleanup with
+ * MCP_IDLE_EXIT_MS.
  */
-export const DEFAULT_IDLE_EXIT_MS = 900_000
+export const DEFAULT_IDLE_EXIT_MS = 0
 
 /**
  * Lower bound for the idle interval to prevent event-loop saturation.
@@ -1444,8 +1447,8 @@ interface IdleExitEnv {
 /**
  * Create idle shutdown wiring from process-style environment values.
  *
- * Why: startTscServer should exercise the same default-on / disabled parsing
- * as unit tests without making runtime smoke wait for the 15-minute default.
+ * Why: startTscServer should exercise the same opt-in / disabled parsing as
+ * unit tests.
  */
 export function createIdleShutdownWatcherFromEnv(opts: {
 	env: IdleExitEnv

--- a/packages/tsc-runner/mcp/index.ts
+++ b/packages/tsc-runner/mcp/index.ts
@@ -185,16 +185,24 @@ interface ToolFailure {
 	code: ToolErrorCode
 	message: string
 	remediationHint?: string
+	cwd?: string
 }
 
 class TscToolError extends Error {
 	code: ToolErrorCode
 	remediationHint?: string
+	cwd?: string
 
-	constructor(code: ToolErrorCode, message: string, remediationHint?: string) {
+	constructor(
+		code: ToolErrorCode,
+		message: string,
+		remediationHint?: string,
+		cwd?: string,
+	) {
 		super(message)
 		this.code = code
 		this.remediationHint = remediationHint
+		this.cwd = cwd
 	}
 }
 
@@ -223,6 +231,19 @@ const PACKAGE_VERSION: string = JSON.parse(
 export const SERVER_VERSION: string = PACKAGE_VERSION
 
 let _gitRootPromise: Promise<string> | null = null
+let _repositoryContextPromise: Promise<RepositoryContext> | null = null
+
+interface RepositoryContext {
+	worktreeRoot: string
+	gitCommonDir: string
+}
+
+interface PathContext {
+	realPath: string
+	worktreeRoot: string
+	startupRoot: string
+	gitCommonDir: string
+}
 
 /**
  * Get the git root once per process using promise coalescing.
@@ -235,12 +256,36 @@ export function getGitRoot(): Promise<string> {
 	if (_gitRootPromise !== null) {
 		return _gitRootPromise
 	}
-	_gitRootPromise = resolveGitRoot()
+	_gitRootPromise = getStartupRepositoryContext().then(
+		(context) => context.worktreeRoot,
+	)
 	return _gitRootPromise
 }
 
-async function resolveGitRoot(): Promise<string> {
-	const proc = Bun.spawn(['git', 'rev-parse', '--show-toplevel'], {
+async function getStartupRepositoryContext(): Promise<RepositoryContext> {
+	if (_repositoryContextPromise !== null) {
+		return _repositoryContextPromise
+	}
+	_repositoryContextPromise = resolveRepositoryContext(process.cwd())
+	return _repositoryContextPromise
+}
+
+async function resolveRepositoryContext(
+	cwd: string,
+): Promise<RepositoryContext> {
+	const [worktreeRoot, gitCommonDir] = await Promise.all([
+		resolveGitPath(cwd, ['--show-toplevel']),
+		resolveGitPath(cwd, ['--path-format=absolute', '--git-common-dir']),
+	])
+
+	return {
+		worktreeRoot: await realpath(worktreeRoot),
+		gitCommonDir: await realpath(gitCommonDir),
+	}
+}
+
+async function resolveGitPath(cwd: string, args: string[]): Promise<string> {
+	const proc = Bun.spawn(['git', '-C', cwd, 'rev-parse', ...args], {
 		stdout: 'pipe',
 		stderr: 'pipe',
 	})
@@ -254,7 +299,7 @@ async function resolveGitRoot(): Promise<string> {
 		throw new Error('Not inside a git repository')
 	}
 
-	return realpath(stdout.trim())
+	return stdout.trim()
 }
 
 /**
@@ -264,6 +309,7 @@ async function resolveGitRoot(): Promise<string> {
  */
 export function _resetGitRootCache(): void {
 	_gitRootPromise = null
+	_repositoryContextPromise = null
 }
 
 /**
@@ -276,11 +322,17 @@ export function _resetGitRootCache(): void {
 export async function validatePathOrDefault(
 	inputPath?: string,
 ): Promise<string> {
+	return (await resolvePathContextOrDefault(inputPath)).realPath
+}
+
+async function resolvePathContextOrDefault(
+	inputPath?: string,
+): Promise<PathContext> {
 	const candidate =
 		inputPath === undefined || inputPath.trim() === ''
 			? process.cwd()
 			: inputPath
-	return validatePath(candidate)
+	return resolvePathContext(candidate)
 }
 
 /**
@@ -290,6 +342,13 @@ export async function validatePathOrDefault(
  * escapes before any filesystem reads or command execution.
  */
 export async function validatePath(inputPath: string): Promise<string> {
+	return (await resolvePathContext(inputPath)).realPath
+}
+
+export async function resolvePathContext(
+	inputPath: string,
+	options?: { baseDir?: string },
+): Promise<PathContext> {
 	if (inputPath.includes('\x00')) {
 		throw new Error('Path contains null byte')
 	}
@@ -302,26 +361,63 @@ export async function validatePath(inputPath: string): Promise<string> {
 		throw new Error('Path cannot be empty')
 	}
 
-	const resolvedPath = path.resolve(inputPath)
+	const resolvedPath = path.resolve(
+		options?.baseDir ?? process.cwd(),
+		inputPath,
+	)
 	let realInputPath: string
+	let nearestExistingDir: string
 
 	try {
 		realInputPath = await realpath(resolvedPath)
+		nearestExistingDir = (await stat(realInputPath)).isDirectory()
+			? realInputPath
+			: path.dirname(realInputPath)
 	} catch (error) {
 		const err = error as NodeJS.ErrnoException
 		if (err.code === 'ENOENT') {
-			realInputPath = await resolveNearestAncestor(resolvedPath)
+			const resolved = await resolveNearestAncestor(resolvedPath)
+			realInputPath = resolved.realPath
+			nearestExistingDir = resolved.nearestExistingDir
 		} else {
 			throw new Error(`Cannot resolve path: ${err.message}`)
 		}
 	}
 
-	const gitRoot = await getGitRoot()
-	if (realInputPath !== gitRoot && !realInputPath.startsWith(`${gitRoot}/`)) {
-		throw new Error(`Path outside repository: ${inputPath}`)
+	const startupContext = await getStartupRepositoryContext()
+	if (isPathInsideOrEqual(realInputPath, startupContext.worktreeRoot)) {
+		return {
+			realPath: realInputPath,
+			worktreeRoot: startupContext.worktreeRoot,
+			startupRoot: startupContext.worktreeRoot,
+			gitCommonDir: startupContext.gitCommonDir,
+		}
 	}
 
-	return realInputPath
+	let targetContext: RepositoryContext
+	try {
+		targetContext = await resolveRepositoryContext(nearestExistingDir)
+	} catch {
+		throw new Error(
+			`Path outside configured runner repository or linked worktrees: ${inputPath}`,
+		)
+	}
+
+	if (
+		targetContext.gitCommonDir === startupContext.gitCommonDir &&
+		isPathInsideOrEqual(realInputPath, targetContext.worktreeRoot)
+	) {
+		return {
+			realPath: realInputPath,
+			worktreeRoot: targetContext.worktreeRoot,
+			startupRoot: startupContext.worktreeRoot,
+			gitCommonDir: targetContext.gitCommonDir,
+		}
+	}
+
+	throw new Error(
+		`Path outside configured runner repository or linked worktrees: ${inputPath}`,
+	)
 }
 
 function hasControlCharacters(value: string): boolean {
@@ -341,7 +437,10 @@ function hasControlCharacters(value: string): boolean {
  * Why: a naive fallback to path.resolve on ENOENT misses intermediate symlinks
  * that could escape the repository boundary.
  */
-async function resolveNearestAncestor(resolvedPath: string): Promise<string> {
+async function resolveNearestAncestor(resolvedPath: string): Promise<{
+	realPath: string
+	nearestExistingDir: string
+}> {
 	let dir = path.dirname(resolvedPath)
 	const suffix = path.basename(resolvedPath)
 	const segments: string[] = [suffix]
@@ -349,14 +448,30 @@ async function resolveNearestAncestor(resolvedPath: string): Promise<string> {
 	while (dir !== path.dirname(dir)) {
 		try {
 			const realDir = await realpath(dir)
-			return path.join(realDir, ...segments)
+			return {
+				realPath: path.join(realDir, ...segments),
+				nearestExistingDir: realDir,
+			}
 		} catch {
 			segments.unshift(path.basename(dir))
 			dir = path.dirname(dir)
 		}
 	}
 
-	return resolvedPath
+	return {
+		realPath: resolvedPath,
+		nearestExistingDir: path.dirname(resolvedPath),
+	}
+}
+
+function isPathInsideOrEqual(candidatePath: string, rootPath: string): boolean {
+	const relative = path.relative(rootPath, candidatePath)
+	return (
+		relative === '' ||
+		(relative.length > 0 &&
+			!relative.startsWith('..') &&
+			!path.isAbsolute(relative))
+	)
 }
 
 /**
@@ -388,24 +503,27 @@ export function parseTscOutput(output: string): TscParseResult {
 }
 
 /**
- * Find nearest tsconfig/jsconfig bounded to the current git root.
+ * Find nearest tsconfig/jsconfig bounded to a worktree root.
  *
  * Why: unbounded upward traversal can leak repository context and hit unrelated
  * configs outside the project boundary.
  */
-export async function findNearestTsConfig(filePath: string): Promise<{
+export async function findNearestTsConfig(
+	filePath: string,
+	boundaryRoot?: string,
+): Promise<{
 	found: boolean
 	configDir?: string
 	configPath?: string
 }> {
-	const gitRoot = await getGitRoot()
+	const gitRoot = boundaryRoot ?? (await getGitRoot())
 	let current = path.dirname(path.resolve(filePath))
 
-	if (current !== gitRoot && !current.startsWith(`${gitRoot}/`)) {
+	if (!isPathInsideOrEqual(current, gitRoot)) {
 		return { found: false }
 	}
 
-	while (current === gitRoot || current.startsWith(`${gitRoot}/`)) {
+	while (isPathInsideOrEqual(current, gitRoot)) {
 		for (const configFile of TSC_CONFIG_FILES) {
 			const candidatePath = path.join(current, configFile)
 			if (await fileExists(candidatePath)) {
@@ -444,10 +562,17 @@ async function resolveWorkdir(targetPath?: string): Promise<{
 	cwd: string
 	configPath: string
 }> {
-	const resolved = await validatePathOrDefault(targetPath)
+	const pathContext = await resolvePathContextOrDefault(targetPath)
+	const resolved = pathContext.realPath
+	const boundaryRoot = pathContext.worktreeRoot
 
 	if (!(await fileExists(resolved))) {
-		throw new TscToolError('PATH_NOT_FOUND', `Path not found: ${resolved}`)
+		throw new TscToolError(
+			'PATH_NOT_FOUND',
+			`Path not found: ${resolved}`,
+			undefined,
+			boundaryRoot,
+		)
 	}
 
 	const fileStat = await stat(resolved)
@@ -460,7 +585,10 @@ async function resolveWorkdir(targetPath?: string): Promise<{
 			}
 		}
 
-		const nearest = await findNearestTsConfig(path.join(resolved, 'index.ts'))
+		const nearest = await findNearestTsConfig(
+			path.join(resolved, 'index.ts'),
+			boundaryRoot,
+		)
 		if (nearest.found && nearest.configDir && nearest.configPath) {
 			return { cwd: nearest.configDir, configPath: nearest.configPath }
 		}
@@ -468,10 +596,12 @@ async function resolveWorkdir(targetPath?: string): Promise<{
 		throw new TscToolError(
 			'CONFIG_NOT_FOUND',
 			`No tsconfig.json or jsconfig.json found for directory ${resolved}`,
+			undefined,
+			boundaryRoot,
 		)
 	}
 
-	const nearest = await findNearestTsConfig(resolved)
+	const nearest = await findNearestTsConfig(resolved, boundaryRoot)
 	if (nearest.found && nearest.configDir && nearest.configPath) {
 		return { cwd: nearest.configDir, configPath: nearest.configPath }
 	}
@@ -479,6 +609,8 @@ async function resolveWorkdir(targetPath?: string): Promise<{
 	throw new TscToolError(
 		'CONFIG_NOT_FOUND',
 		`No tsconfig.json or jsconfig.json found for file ${resolved}`,
+		undefined,
+		boundaryRoot,
 	)
 }
 
@@ -511,6 +643,8 @@ export async function spawnWithTimeout(
 			throw new TscToolError(
 				'SPAWN_FAILURE',
 				`Failed to start TypeScript compiler: ${message}`,
+				undefined,
+				options?.cwd,
 			)
 		}
 	})()
@@ -565,12 +699,16 @@ async function runTsc(cwd: string, configPath: string): Promise<TscOutput> {
 		throw new TscToolError(
 			'TIMEOUT',
 			`TypeScript check timed out after ${TSC_TIMEOUT_MS / 1000}s in ${cwd}.`,
+			undefined,
+			cwd,
 		)
 	}
 	if (stdoutTruncated || stderrTruncated) {
 		throw new TscToolError(
 			'SPAWN_FAILURE',
 			`TypeScript output exceeded ${TSC_OUTPUT_CAPTURE_MAX_BYTES} bytes in ${cwd}. Narrow scope or reduce compiler verbosity.`,
+			undefined,
+			cwd,
 		)
 	}
 
@@ -585,6 +723,8 @@ async function runTsc(cwd: string, configPath: string): Promise<TscOutput> {
 		throw new TscToolError(
 			'SPAWN_FAILURE',
 			`Failed to start TypeScript compiler from ${cwd}: ${stderr.trim()}`,
+			undefined,
+			cwd,
 		)
 	}
 
@@ -719,6 +859,7 @@ function toToolFailure(error: unknown): ToolFailure {
 			code: error.code,
 			message: error.message,
 			remediationHint: error.remediationHint,
+			cwd: error.cwd,
 		}
 	}
 
@@ -1064,7 +1205,7 @@ export async function createTscServer(
 						} catch (error) {
 							const failure = toToolFailure(error)
 							const failureOutput: TscOutput = {
-								cwd: process.cwd(),
+								cwd: failure.cwd ?? process.cwd(),
 								configPath: '',
 								timedOut: failure.code === 'TIMEOUT',
 								exitCode: 1,

--- a/scripts/smoke/run-smoke.ts
+++ b/scripts/smoke/run-smoke.ts
@@ -7,7 +7,15 @@
  * against an isolated temporary sandbox rooted inside this repository.
  */
 
-import { appendFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import {
+	appendFile,
+	mkdir,
+	mkdtemp,
+	realpath,
+	rm,
+	writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
@@ -20,6 +28,7 @@ interface RunnerCase {
 		| 'claude-hooks'
 		| 'orphan-detection'
 		| 'idle-shutdown'
+		| 'linked-worktree-paths'
 	entrypoint: string
 	run(sandboxRoot: string): Promise<void>
 }
@@ -94,6 +103,41 @@ async function createSandboxRoot(prefix: string): Promise<string> {
 	await mkdir(parent, { recursive: true })
 	const root = await mkdtemp(path.join(parent, `${prefix}-`))
 	return root
+}
+
+async function runGit(args: string[], cwd = REPO_ROOT): Promise<void> {
+	const proc = Bun.spawn(['git', ...args], {
+		cwd,
+		stdout: 'pipe',
+		stderr: 'pipe',
+	})
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	])
+	assert(
+		exitCode === 0,
+		`git ${args.join(' ')} failed with ${exitCode}: ${stdout}${stderr}`,
+	)
+}
+
+async function createLinkedWorktree(prefix: string): Promise<{
+	worktree: string
+	cleanup: () => Promise<void>
+}> {
+	const parent = await mkdtemp(path.join(tmpdir(), `${prefix}-`))
+	const worktree = path.join(parent, 'checkout')
+	await runGit(['worktree', 'add', '--detach', worktree, 'HEAD'])
+	return {
+		worktree,
+		cleanup: async () => {
+			await runGit(['worktree', 'remove', '--force', worktree]).catch(
+				() => undefined,
+			)
+			await rm(parent, { recursive: true, force: true })
+		},
+	}
 }
 
 async function withRunnerClient<T>(args: {
@@ -570,6 +614,150 @@ function createSmokeEnv(
 	return { ...env, ...overrides }
 }
 
+function getProductionRunner(
+	name: ProductionRunnerBinary['name'],
+): ProductionRunnerBinary {
+	const runner = PRODUCTION_RUNNER_BINARIES.find((entry) => entry.name === name)
+	assert(runner, `Production runner not found: ${name}`)
+	return runner
+}
+
+function assertCwdUnderWorktree(args: {
+	actual: unknown
+	expected: string
+	worktree: string
+	label: string
+}): void {
+	assert(typeof args.actual === 'string', `${args.label} missing cwd`)
+	assert(
+		args.actual === args.expected,
+		`${args.label} expected cwd ${args.expected}, got ${args.actual}`,
+	)
+	assert(
+		args.actual === args.worktree ||
+			args.actual.startsWith(`${args.worktree}/`),
+		`${args.label} cwd was not inside linked worktree: ${args.actual}`,
+	)
+}
+
+async function runLinkedWorktreePathSmoke(_sandboxRoot: string): Promise<void> {
+	await buildProductionRunnerBinaries()
+
+	const { worktree, cleanup } = await createLinkedWorktree(
+		'side-quest-linked-worktree-smoke',
+	)
+	try {
+		const realWorktree = await realpath(worktree)
+
+		const tscProject = path.join(worktree, 'reports', 'linked-smoke-tsc')
+		await mkdir(tscProject, { recursive: true })
+		await writeFile(
+			path.join(tscProject, 'tsconfig.json'),
+			JSON.stringify(
+				{
+					compilerOptions: {
+						target: 'ES2022',
+						module: 'NodeNext',
+						moduleResolution: 'NodeNext',
+						strict: true,
+						noEmit: true,
+						skipLibCheck: true,
+						types: [],
+					},
+				},
+				null,
+				2,
+			),
+		)
+		await writeFile(path.join(tscProject, 'index.ts'), 'const ok = 1;\n')
+
+		const bunProject = path.join(worktree, 'reports', 'linked-smoke-bun')
+		await mkdir(bunProject, { recursive: true })
+		const bunTestFile = path.join(bunProject, 'pass.test.ts')
+		await writeFile(
+			bunTestFile,
+			"import { expect, test } from 'bun:test';\ntest('linked smoke pass', () => expect(2 + 2).toBe(4));\n",
+		)
+
+		const biomeProject = path.join(worktree, 'reports', 'linked-smoke-biome')
+		await mkdir(biomeProject, { recursive: true })
+		const biomeFile = path.join(biomeProject, 'good.js')
+		await writeFile(biomeFile, 'export const ok = 1\n')
+
+		const tscRunner = getProductionRunner('tsc-runner')
+		await withRunnerClient({
+			entrypoint: tscRunner.entrypoint,
+			cwd: tscRunner.packageDir,
+			run: async (client) => {
+				const result = await callTool(client, 'tsc_check', {
+					path: tscProject,
+					response_format: 'json',
+				})
+				assert(result.isError === false, 'linked tsc_check failed')
+				const output = result.structuredContent
+				assertObject(output, 'linked tsc_check structuredContent')
+				assert(output.errorCount === 0, 'linked tsc_check expected 0 errors')
+				assertCwdUnderWorktree({
+					actual: output.cwd,
+					expected: await realpath(tscProject),
+					worktree: realWorktree,
+					label: 'linked tsc_check',
+				})
+			},
+		})
+
+		const bunRunner = getProductionRunner('bun-runner')
+		await withRunnerClient({
+			entrypoint: bunRunner.entrypoint,
+			cwd: bunRunner.packageDir,
+			run: async (client) => {
+				const result = await callTool(client, 'bun_runTests', {
+					cwd: worktree,
+					pattern: bunTestFile,
+					response_format: 'json',
+				})
+				assert(result.isError === false, 'linked bun_runTests failed')
+				const output = result.structuredContent
+				assertObject(output, 'linked bun_runTests structuredContent')
+				assert(output.failed === 0, 'linked bun_runTests expected 0 failures')
+				assertCwdUnderWorktree({
+					actual: output.cwd,
+					expected: realWorktree,
+					worktree: realWorktree,
+					label: 'linked bun_runTests',
+				})
+			},
+		})
+
+		const biomeRunner = getProductionRunner('biome-runner')
+		await withRunnerClient({
+			entrypoint: biomeRunner.entrypoint,
+			cwd: biomeRunner.packageDir,
+			run: async (client) => {
+				const result = await callTool(client, 'biome_lintCheck', {
+					path: biomeFile,
+					response_format: 'json',
+				})
+				assert(result.isError === false, 'linked biome_lintCheck failed')
+				const output = result.structuredContent
+				assertObject(output, 'linked biome_lintCheck structuredContent')
+				assert(
+					output.errorCount === 0,
+					'linked biome_lintCheck expected 0 errors',
+				)
+				assertCwdUnderWorktree({
+					actual: output.cwd,
+					expected: realWorktree,
+					worktree: realWorktree,
+					label: 'linked biome_lintCheck',
+				})
+			},
+		})
+	} finally {
+		await cleanup()
+	}
+}
+
 async function writeIdleActivityFixture(
 	runnerName: ProductionRunnerBinary['name'],
 	projectDir: string,
@@ -995,6 +1183,11 @@ async function run(): Promise<void> {
 			name: 'claude-hooks',
 			entrypoint: path.join(REPO_ROOT, 'packages/claude-hooks/hooks/index.ts'),
 			run: runClaudeHooksSmoke,
+		},
+		{
+			name: 'linked-worktree-paths',
+			entrypoint: path.join(REPO_ROOT, 'packages/bun-runner/dist/index.js'),
+			run: runLinkedWorktreePathSmoke,
 		},
 		{
 			name: 'orphan-detection',


### PR DESCRIPTION
## Summary

Codex worktrees can now use the Bun, Biome, and TypeScript MCP runners without falling back to raw repo CLIs. Paths are accepted when they live in the startup checkout or a linked Git worktree that shares the same Git common dir, while unrelated repositories and symlink escapes stay blocked.

JSON responses now include the resolved `cwd`, so agents can verify diagnostics came from the active worktree. Bun suite-level tools also accept an explicit `cwd`, and mixed-checkout requests are rejected instead of silently running one checkout against another.

Closes #71.

## Design Notes

- The trust boundary remains the configured repository: startup checkout plus linked worktrees with the same Git common dir.
- Path-bearing tools run from the worktree selected by the validated path, so config discovery and dependency lookup match the target checkout.
- TSC config search is bounded to the selected worktree, preventing fallback to the server startup checkout.
- The helper stays local to each runner for now, preserving the current self-contained package structure.

## Testing

- `bun_testFile` for Bun runner tests: 62/62
- `bun_testFile` for Biome runner tests: 50/50
- `bun_testFile` for TSC runner tests: 60/60
- `bun_runTests`: 209/209
- `tsc_check`
- `biome_lintCheck`
- `bun run build`
- `bun test:smoke`

## Post-Deploy Monitoring & Validation

Validation window: first 24 hours after npm publish. Owner: maintainer merging this PR.

Watch:

- GitHub Actions release and quality workflows for failures mentioning `linked-worktree-paths`, `Path outside configured runner repository or linked worktrees`, `CONFIG_NOT_FOUND`, or `cwd`.
- GitHub issues for `Path outside repository`, `worktree`, `Codex`, `cwd`, and runner-specific reports against `bun_runTests`, `biome_lintCheck`, or `tsc_check`.
- npm publish workflow status for `@side-quest/bun-runner`, `@side-quest/biome-runner`, and `@side-quest/tsc-runner`.

Healthy signals:

- PR quality and smoke tests stay green.
- Published runners accept linked-worktree paths and report a `cwd` under the selected worktree.
- No new reports of unrelated repositories being accepted.

Failure signals and mitigation:

- Linked worktree paths still fail with boundary errors: reproduce with `bun test:smoke`, inspect Git common-dir comparison, and patch validation.
- Unrelated repositories are accepted: revert or hotfix the release immediately because the runner boundary expanded too far.
- TSC reports configs from the startup checkout: inspect bounded config search and add a targeted regression case.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runners now accept Git linked worktree paths in addition to startup checkout paths.
  * JSON responses include the resolved execution `cwd`; test/coverage tools accept optional `cwd` for worktree-scoped runs.

* **Behavior Changes**
  * Idle shutdown is now disabled by default (opt-in via `MCP_IDLE_EXIT_MS`).

* **Documentation**
  * Updated runner READMEs and added/expanded the release plan to describe linked worktrees and `cwd` in JSON responses.

* **Tests**
  * Expanded unit, integration, and smoke coverage for linked-worktree path validation, `cwd` propagation, and related error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->