### PR TITLE
fix(bun-runner): parse fail-marker runtime failures

### DIFF
--- a/.changeset/fix-bun-fail-marker-parser.md
+++ b/.changeset/fix-bun-fail-marker-parser.md
@@ -1,0 +1,5 @@
+---
+"@side-quest/bun-runner": patch
+---
+
+Parse Bun timeout and runtime failures that emit a `(fail)` marker without a preceding `error:` block.

--- a/packages/bun-runner/mcp/index.test.ts
+++ b/packages/bun-runner/mcp/index.test.ts
@@ -261,6 +261,61 @@ error: actual test error
 		expect(result.failures[0]?.file).toBe('/path/fail.ts')
 	})
 
+	test('parses timeout failures without a preceding error block', () => {
+		const output = `bun test v1.3.14 (0d9b296a)
+
+skills/test-runner/scripts/fixtures/timeout.test.ts:
+(fail) timeout fixture > times out a slow promise [51.18ms]
+  ^ this test timed out after 50ms.
+
+ 0 pass
+ 1 fail
+Ran 1 test across 1 file. [69.00ms]`
+
+		const result = parseBunTestOutput(output)
+
+		expect(result.passed).toBe(0)
+		expect(result.failed).toBe(1)
+		expect(result.failures).toHaveLength(1)
+		expect(result.failures[0]?.file).toBe('skills/test-runner/scripts/fixtures/timeout.test.ts')
+		expect(result.failures[0]?.message).toContain('timeout fixture > times out a slow promise')
+		expect(result.failures[0]?.message).toContain('this test timed out after 50ms')
+	})
+
+	test('parses runtime errors without a preceding error block', () => {
+		const output = `bun test v1.3.14 (0d9b296a)
+
+skills/test-runner/scripts/fixtures/runtime-error.test.ts:
+1 | import { describe, test } from "bun:test";
+2 |
+3 | function normalizeName(value: unknown): string {
+4 | 	return (value as { name: string }).name.toUpperCase();
+             ^
+TypeError: null is not an object (evaluating 'value.name')
+      at normalizeName (/repo/skills/test-runner/scripts/fixtures/runtime-error.test.ts:4:10)
+      at <anonymous> (/repo/skills/test-runner/scripts/fixtures/runtime-error.test.ts:9:3)
+(fail) runtime error fixture > reports runtime type failure [0.83ms]
+
+ 0 pass
+ 1 fail
+Ran 1 test across 1 file. [17.00ms]`
+
+		const result = parseBunTestOutput(output)
+
+		expect(result.passed).toBe(0)
+		expect(result.failed).toBe(1)
+		expect(result.failures).toHaveLength(1)
+		expect(result.failures[0]?.file).toBe(
+			'/repo/skills/test-runner/scripts/fixtures/runtime-error.test.ts',
+		)
+		expect(result.failures[0]?.line).toBe(4)
+		expect(result.failures[0]?.message).toContain(
+			'runtime error fixture > reports runtime type failure',
+		)
+		expect(result.failures[0]?.message).toContain('TypeError: null is not an object')
+		expect(result.failures[0]?.stack).toContain('at normalizeName')
+	})
+
 	test('discards orphan error: blocks without (fail) marker in v1.3+ format', () => {
 		// Orphan error: lines that are never terminated by (fail)
 		// should be discarded as they're likely console.error output

--- a/packages/bun-runner/mcp/parse-utils.ts
+++ b/packages/bun-runner/mcp/parse-utils.ts
@@ -75,22 +75,68 @@ function parseFailureDetails(output: string): TestFailure[] {
 	const failures: TestFailure[] = []
 	const lines = output.split('\n')
 	let currentFailure: TestFailure | null = null
-	let currentTestName: string | undefined
+	let currentFailureStartedByFailMarker = false
+	let currentFile = 'unknown'
+	let pendingDiagnosticLines: string[] = []
 
 	for (const line of lines) {
 		if (!line) continue
+
+		const fileHeaderMatch = line
+			.trim()
+			.match(/^(.+\.(?:test|spec)\.[cm]?[jt]sx?):$/)
+		if (fileHeaderMatch?.[1]) {
+			finalizeFailMarkerFallback()
+			currentFile = fileHeaderMatch[1]
+			pendingDiagnosticLines = []
+			continue
+		}
 
 		// Bun v1.3+ format: "(fail) test name [0.21ms]" marks end of failure block
 		// Extract test name and finalize the failure
 		const failMatch = line.match(/\(fail\)\s+(.+?)\s+\[/)
 		if (failMatch) {
+			const testName = failMatch[1] ?? 'unknown test'
 			if (currentFailure) {
-				// Use the test name from (fail) line as the primary identifier
-				currentTestName = failMatch[1]
-				currentFailure.message = `${currentTestName}: ${currentFailure.message}`
-				failures.push(currentFailure)
+				if (currentFailureStartedByFailMarker) {
+					failures.push(currentFailure)
+					currentFailure = createFailureFromFailMarker(
+						testName,
+						currentFile,
+						pendingDiagnosticLines,
+					)
+					currentFailureStartedByFailMarker = true
+				} else {
+					// Use the test name from (fail) line as the primary identifier
+					currentFailure.message = `${testName}: ${currentFailure.message}`
+					failures.push(currentFailure)
+					currentFailure = null
+					currentFailureStartedByFailMarker = false
+				}
+			} else {
+				currentFailure = createFailureFromFailMarker(
+					testName,
+					currentFile,
+					pendingDiagnosticLines,
+				)
+				currentFailureStartedByFailMarker = true
+			}
+			pendingDiagnosticLines = []
+			continue
+		}
+
+		if (line.match(/^\s*\d+ (?:pass|fail)$/) || line.startsWith('Ran ')) {
+			finalizeFailMarkerFallback()
+			pendingDiagnosticLines = []
+			continue
+		}
+
+		if (line.match(/^\(pass\) /)) {
+			if (!currentFailureStartedByFailMarker) {
 				currentFailure = null
 			}
+			currentFailureStartedByFailMarker = false
+			pendingDiagnosticLines = []
 			continue
 		}
 
@@ -115,10 +161,12 @@ function parseFailureDetails(output: string): TestFailure[] {
 			} else {
 				// Start tentative failure block - will only be kept if (fail) marker follows
 				currentFailure = {
-					file: 'unknown',
+					file: currentFile,
 					message: line.trim(),
 				}
 			}
+			currentFailureStartedByFailMarker = false
+			pendingDiagnosticLines = []
 			continue
 		}
 
@@ -138,8 +186,12 @@ function parseFailureDetails(output: string): TestFailure[] {
 				// Append to message (skip source code lines like "3 | test(...)")
 				currentFailure.message += `\n${line.trim()}`
 			}
+		} else if (isUsefulPendingDiagnosticLine(line)) {
+			pendingDiagnosticLines.push(line.trim())
 		}
 	}
+
+	finalizeFailMarkerFallback()
 
 	// For legacy format (✗ or FAIL), push remaining failure
 	// For v1.3+ format, orphan failures without (fail) marker are discarded
@@ -153,4 +205,55 @@ function parseFailureDetails(output: string): TestFailure[] {
 	}
 
 	return failures
+
+	function finalizeFailMarkerFallback(): void {
+		if (currentFailure && currentFailureStartedByFailMarker) {
+			failures.push(currentFailure)
+			currentFailure = null
+			currentFailureStartedByFailMarker = false
+		}
+	}
+}
+
+function createFailureFromFailMarker(
+	testName: string,
+	currentFile: string,
+	pendingDiagnosticLines: string[],
+): TestFailure {
+	const stack = pendingDiagnosticLines
+		.filter((line) => line.trim().startsWith('at '))
+		.map((line) => `${line}\n`)
+		.join('')
+	const topFrame = pendingDiagnosticLines.find((line) =>
+		line.trim().startsWith('at '),
+	)
+	const frameMatch =
+		topFrame?.match(/\((.+):(\d+):(\d+)\)/) ||
+		topFrame?.match(/at (.+):(\d+):(\d+)/)
+	const file = frameMatch?.[1] ?? currentFile
+	const line = frameMatch?.[2] ? Number.parseInt(frameMatch[2], 10) : undefined
+	const diagnosticMessage = pendingDiagnosticLines
+		.filter((line) => !line.trim().startsWith('at '))
+		.join('\n')
+	const message = diagnosticMessage
+		? `${testName}: ${diagnosticMessage}`
+		: testName
+
+	return {
+		file,
+		message,
+		...(line === undefined ? {} : { line }),
+		...(stack ? { stack } : {}),
+	}
+}
+
+function isUsefulPendingDiagnosticLine(line: string): boolean {
+	const trimmed = line.trim()
+	return (
+		trimmed.length > 0 &&
+		!trimmed.startsWith('bun test ') &&
+		!trimmed.match(/^\d+ \| /) &&
+		trimmed !== '^' &&
+		!trimmed.match(/^-+$/)
+	)
 }


### PR DESCRIPTION
## Summary

- parse Bun `(fail)` marker failures even when no preceding `error:` block started a failure
- carry the current test file header and pending runtime diagnostics into fallback failures
- add regression coverage for timeout and runtime type failures
- add a patch changeset for `@side-quest/bun-runner`

## Why

Bun timeout and runtime-error output can report `1 fail` while emitting `(fail)` without an earlier `error:` line. The MCP parser trusted the summary count but returned `failures: []`, which made downstream benchmark baselines unfaithful and artificially tiny.

## Verification

- `bun test packages/bun-runner/mcp/index.test.ts --timeout 30000`
- `bun run --filter @side-quest/bun-runner typecheck`
- `bun run --filter @side-quest/bun-runner build`
- `bun run --filter @side-quest/bun-runner test`
- `bun run quality-check:ci`
- `bun run build`
- `TF_BUILD=true bun run test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Bun test runner to correctly parse timeout and runtime failures that emit failure markers without a preceding error block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->